### PR TITLE
Fix snow bug

### DIFF
--- a/src/glm_surface.c
+++ b/src/glm_surface.c
@@ -1159,7 +1159,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
         //  Use 1:10 rule for snow water equivalent
         //---------------------------------------------------------------------+
         Lake[surfLayer].Height += MAX( MetData.Snow, zero)
-                 * Lake[surfLayer].LayerArea * (1./10.) * (noSecs / SecsPerDay);
+                 * (1./10.) * (noSecs / SecsPerDay);
 
         recalc_surface_salt();
     }


### PR DESCRIPTION
The formula in lines 1161-1162 is calculating a volume increase rather than a height increase, as expected. As a result, an excessive increase in height is calculated, bringing water level and volume outside the range of values of the provided bathymetry and making the model to crash, sometimes with the error "Array bounds error - too many layers" (e.g., see https://groups.google.com/forum/#!category-topic/aquaticmodelling/glm/2ZxGiKXI5Fc). The suggested modification fixes this issue.