### PR TITLE
Solve DailyKw issue

### DIFF
--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -305,7 +305,7 @@ void do_model(int jstart, int nsave)
         WithdrawalTemp = (WithdrTempOld + WithdrTempNew) / 2.0;
 
         read_daily_kw(jday, &DailyKw);
-        for (i = botmLayer; i <= surfLayer; i++) Lake[i].ExtcCoefSW = DailyKw;
+        for (i = 0; i <= MaxLayers; i++) Lake[i].ExtcCoefSW = DailyKw;
 
         read_daily_met(jday, &MetNew);
         if ( !subdaily ) {
@@ -440,7 +440,7 @@ void do_model_non_avg(int jstart, int nsave)
 
         //# Read & set today's Kw (if being read in)
         read_daily_kw(jday, &DailyKw);
-        for (i = botmLayer; i <= surfLayer; i++) Lake[i].ExtcCoefSW = DailyKw;
+        for (i = 0; i <= MaxLayers; i++) Lake[i].ExtcCoefSW = DailyKw;
 
         //# Read & set today's meterological data
         read_daily_met(jday, &MetData);
@@ -556,7 +556,7 @@ void do_model_coupled(int step_start, int step_end,
     //  WithdrawalTemp = WithdrTempNew;
 
         read_daily_kw(jday, &DailyKw);
-        for (i = botmLayer; i <= surfLayer; i++) Lake[i].ExtcCoefSW = DailyKw;
+        for (i = 0; i <= MaxLayers; i++) Lake[i].ExtcCoefSW = DailyKw;
 
         read_daily_met(jday, &MetData);
         SWnew = MetData.ShortWave;


### PR DESCRIPTION
A colleague of mine and myself have been testing the new variable Kw functionality. However, when using a Kw_file in hourly simulations, we observed that unexpectedly GLM used the default Kw value for some layers near the surface on occasions. We expected GLM to use the DailyKw specified in the Kw_file in all layers.

After some testing and analysis of the code, we found the following explanation for this issue.
At the start of the simulation GLM assigns the Kw value to all layers (glm_init.c, l. 644):
for (i = ; i < MaxLayers; i++) Lake[i].ExtcCoefSW = Kw;
However, when using a Kw_file, at the start of each day the value of DailyKw is assigned to cells from bottom to surface (not all layers) (glm_model.c, l. 559 and others):
for (i = botmLayer; i <= surfLayer; i ++) Lake[i].ExtcCoefSW = DailyKw;
As a result -I think it occurs when the surface layer splits- the new layers do not use the daily Kw value, but the Kw value specified at the start of the simulation or the latest ExtcCoefSW value used by that cell.

The proposed change solves the issue.