### PR TITLE
Fixes for time bugs

### DIFF
--- a/src/glm_globals.h
+++ b/src/glm_globals.h
@@ -240,6 +240,7 @@ extern AED_REAL timezone_r, timezone_m, timezone_i, timezone_o;
 extern int nDays;          //# number of days to simulate
 extern AED_REAL timestep;
 extern int noSecs;
+extern int startTOD;
 
 /*----------------------------------------------------------------------------*/
 // DEBUGGING

--- a/src/glm_globals.h
+++ b/src/glm_globals.h
@@ -238,9 +238,11 @@ extern CLOGICAL littoral_sw;
 // TIME
 extern AED_REAL timezone_r, timezone_m, timezone_i, timezone_o;
 extern int nDays;          //# number of days to simulate
+extern int nDates;   //# number of unique dates included in the timespan
 extern AED_REAL timestep;
 extern int noSecs;
 extern int startTOD;
+extern int stopTOD;
 
 /*----------------------------------------------------------------------------*/
 // DEBUGGING

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -71,7 +71,7 @@ char wq_lib[256] = DEFAULT_WQ_LIB;
 
 static void create_lake(int namlst);
 static void initialise_lake(int namlst);
-static int init_time(const char *start, char *stop, int timefmt, int *startTOD, int *nDays);
+static int init_time(const char *start, char *stop, int timefmt, int *startTOD, int *stopTOD, int *nDays);
 
 /*############################################################################*/
 
@@ -930,7 +930,7 @@ for (i = 0; i < n_zones; i++) {
 
     if ( timefmt != 2 ) *stop = 0;
 
-    julianday = init_time(start, stop, timefmt, &startTOD, &nDays);
+    julianday = init_time(start, stop, timefmt, &startTOD, &stopTOD, &nDays);
     free(stop);
     calendar_date(julianday, &jyear, &jmonth, &jday);
     //# Days since start of the year, jyear
@@ -1436,7 +1436,7 @@ void initialise_lake(int namlst)
 #define INIT_T_BEGIN_END  2
 #define INIT_T_BEGIN_STEP 3
 
-static int init_time(const char *start, char *stop, int timefmt, int *startTOD, int *nDays)
+static int init_time(const char *start, char *stop, int timefmt, int *startTOD, int *stopTOD, int *nDays)
 {
     int jul1=0, secs1=0, jul2, secs2=0;
     int nsecs;
@@ -1455,6 +1455,9 @@ static int init_time(const char *start, char *stop, int timefmt, int *startTOD, 
             nsecs = time_diff(jul2, secs2, jul1, secs1);
 
             *nDays = nsecs / 86400;
+
+            // number of unique dates included in the timespan
+            nDates = jul2 - jul1 + 1;
             // CAB - usless code? nsecs = nsecs - 86400*(*nDays);
             break;
         case INIT_T_BEGIN_STEP:
@@ -1463,6 +1466,8 @@ static int init_time(const char *start, char *stop, int timefmt, int *startTOD, 
             nsecs = (*nDays) * 86400;
             jul2  = jul1 + (*nDays);
             secs2 = secs1;
+
+            nDates = *nDays + 1;
 
             write_time_string(stop, jul2, secs2);
             break;
@@ -1473,6 +1478,7 @@ static int init_time(const char *start, char *stop, int timefmt, int *startTOD, 
     }
 
     *startTOD = secs1;  /* also return time of day for first day */
+    *stopTOD = secs2;  /* also return end time of day for last day */
     return jul1;
 }
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1464,7 +1464,7 @@ static int init_time(const char *start, char *stop, int timefmt, int *startTOD, 
 
             nsecs = (*nDays) * 86400;
             jul2  = jul1 + (*nDays);
-            secs2 = (nsecs%86400);
+            secs2 = secs1;
 
             write_time_string(stop, jul2, secs2);
             break;

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -69,8 +69,6 @@ extern AED_REAL   seepage_rate;
 char glm_nml_file[256] = DEFAULT_GLM_NML;
 char wq_lib[256] = DEFAULT_WQ_LIB;
 
-extern int START_TOD;
-
 static void create_lake(int namlst);
 static void initialise_lake(int namlst);
 static int init_time(const char *start, char *stop, int timefmt, int *startTOD, int *nDays);
@@ -932,7 +930,7 @@ for (i = 0; i < n_zones; i++) {
 
     if ( timefmt != 2 ) *stop = 0;
 
-    julianday = init_time(start, stop, timefmt, &START_TOD, &nDays);
+    julianday = init_time(start, stop, timefmt, &startTOD, &nDays);
     free(stop);
     calendar_date(julianday, &jyear, &jmonth, &jday);
     //# Days since start of the year, jyear

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1456,8 +1456,7 @@ static int init_time(const char *start, char *stop, int timefmt, int *startTOD, 
 
             nsecs = time_diff(jul2, secs2, jul1, secs1);
 
-            *nDays = jul2-jul1;
-            if (nsecs < 86400 && jul1 != jul2) nDays = nDays-1;
+            *nDays = nsecs / 86400;
             // CAB - usless code? nsecs = nsecs - 86400*(*nDays);
             break;
         case INIT_T_BEGIN_STEP:

--- a/src/glm_input.c
+++ b/src/glm_input.c
@@ -163,7 +163,7 @@ void read_daily_withdraw_temp(int julian, AED_REAL *withdrTemp)
  ******************************************************************************/
 void read_daily_met(int julian, MetDataType *met)
 {
-    int csv, i, idx, err = 0;
+    int csv, i, idx;
     AED_REAL now, tomorrow, t_val, sol;
     AED_REAL eff_area, surf_area, ld, x_ws;
 
@@ -193,15 +193,6 @@ void read_daily_met(int julian, MetDataType *met)
 
         idx = floor((t_val-floor(t_val))*24+1.e-8); // add 1.e-8 to compensate for rounding error
         // fprintf(stderr, "Read met for %16.8f ; %15.12f (%2d)\n", t_val, (t_val-floor(t_val))*24., idx);
-        if ( idx != i ) {
-            if ( !err ) {
-               int dd,mm,yy;
-               calendar_date(now,&yy,&mm,&dd);
-               fprintf(stderr, "Possible sequence issue in met for day %4d-%02d-%02d\n", yy,mm,dd);
-            }
-            idx = i;
-            err = 1;
-        }
         if (idx >= n_steps) {
             int dd,mm,yy;
             calendar_date(now,&yy,&mm,&dd);

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -104,7 +104,7 @@ int do_subdaily_loop(int stepnum, int jday, int nsave, AED_REAL SWold, AED_REAL 
 //int n_steps_done = 0;
 //#define END_STEPS 30
 static int START_ICLOCK = 0;
-int START_TOD = 0;
+int startTOD = 0;
 
 
 /******************************************************************************
@@ -154,7 +154,7 @@ void init_model(int *jstart, int *nsave)
 #endif
 
     init_glm(jstart, out_dir, out_fn, nsave);
-    START_ICLOCK = (START_TOD + (timestep-1)) / timestep;
+    START_ICLOCK = (startTOD + (timestep-1)) / timestep;
 
 #if PLOTS
     psubday = timestep * (*nsave) / SecsPerDay;

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -103,7 +103,6 @@ int do_subdaily_loop(int stepnum, int jday, int nsave, AED_REAL SWold, AED_REAL 
 
 //int n_steps_done = 0;
 //#define END_STEPS 30
-static int START_ICLOCK = 0;
 int startTOD = 0;
 
 
@@ -154,7 +153,6 @@ void init_model(int *jstart, int *nsave)
 #endif
 
     init_glm(jstart, out_dir, out_fn, nsave);
-    START_ICLOCK = (startTOD + (timestep-1)) / timestep;
 
 #if PLOTS
     psubday = timestep * (*nsave) / SecsPerDay;
@@ -642,8 +640,8 @@ int do_subdaily_loop(int stepnum, int jday, int nsave, AED_REAL SWold, AED_REAL 
     /**************************************************************************
      *  Loop for each second in a day (86400 = #seconds in a day)             *
      **************************************************************************/
-    iclock = START_ICLOCK;
-    START_ICLOCK = 0; /* from now on start at the beginning of the day */
+    iclock = startTOD;
+    startTOD = 0; /* from now on start at the beginning of the day */
     Benthic_Light_pcArea = 0.;
     while (iclock < iSecsPerDay) { //# iclock = seconds counter
         if ( subdaily ) {

--- a/src/glm_output.c
+++ b/src/glm_output.c
@@ -94,7 +94,7 @@ void init_output(int jstart, const char *out_dir, const char *out_fn,
     }
 
     MaxLayers = oMaxLayers;
-    write_time_string(ts,jstart,0);
+    write_time_string(ts,jstart,startTOD);
     snprintf(path, 1024, "%s/%s.nc", out_dir, out_fn);
     ncid = init_glm_ncdf(path, "glm run", Latitude, Longitude, MaxLayers, ts);
 


### PR DESCRIPTION
Hi! I'm working with Professors Quinn Thomas and Cayelan Carey at Virginia Tech, and I've developed some bug fixes regarding time that you might be interested in. Currently, GLM seems to have bugs that arise when we try to run it from any time except midnight to midnight, and we wanted to be able to run it at other times of day. We believe these bug fixes allow GLM to be run from any time of day to any time of day. I've added a list explaining the changes we made below, as well as some testing results that appear to show the correctness of these changes.

### Changes

Commit 1049231
- Problem: if timefmt==2 and the times given span a non-integer number of days, then the variable nDays will be rounded inconsistently (down to 0 if the span is less than 1 day, and up to the next-highest integer if the span is greater than 1 day)
- now nDays is always rounded down to the next-lowest integer if the timespan is a non-integer number of days
- also solves a pointer error with nDays

Commit 36999f9
- Problem: if timefmt==3, variable secs2 is always set equal to 0 even when the stop time should not be midnight
- secs2 should equal secs1, because with timefmt==3 the stop time is an integer number of full days after the start time

Commit 7811929
- Problem: the NetCDF output lists the units for time as hours since midnight of the start day, rather than hours since the given start time. The variable START_TOD is not visible here, where it is needed. In addition, it is capitalized like a constant, which it is not.

Commit 06ead88
- Problem: START_ICLOCK is being set to approximately the start time of day (variable startTOD) divided by the timestep (dt), but it is later used as the start time of day. This means that unless dt==1, the start time of the model is earlier than it should be. It doesn't seem like there's any reason for not simply setting START_ICLOCK equal to startTOD, as it isn't used anywhere else.

Commit 13935ac
- Problem: the program runs by days and doesn't keep track of the stop time for the last day. This means it always runs until the end of the final day and can't stop at a different time of day.
- my solution also allows for running the simulation for finer-grained spans of time than multiples of 24 hours
- [ ] ISSUE: I implemented my solution in all three functions (do_model, do_model_non_avg, and do_model_coupled), but I only checked its accuracy in do_model and do_model_non_avg (not in do_model_coupled), as I'm not familiar with do_model_coupled.

Commit 142522b
- Problem: if the meteorology data file does not start at midnight, then data for the first day will be read incorrectly, because the variable idx will be reset to equal a different counter variable that does start at 0, causing the variable met to be returned with meteorology data shifted to start at midnight
- [ ] ISSUE: I'm not sure what problem the code I deleted was intended to prevent. That should be checked by someone who does know its original intent.

### Testing

I ran several tests comparing results from my modified code and the unmodified code; here are just three tests (with non_avg = .true.) demonstrating that this appears to be correct. For each, I've included a graph of shortwave radiation (I_0), which is read directly from an input file, and a graph of surface temperature, which is derived from calculations. Green represents results from my modified GLM code, and red is results from the original unmodified GLM code. Although these tests are with AED off, Professor Thomas has also tested the modifications with AED on and confirmed that it seems to work.

Test 1: 1 day, 12am to 12am on both unmodified and modified code. Results match up perfectly, as expected.
![i_0_1](https://user-images.githubusercontent.com/26662438/60365991-3a244b00-99b8-11e9-9d96-16ffa02452b5.png)
![surface_temp_1](https://user-images.githubusercontent.com/26662438/60365997-3b557800-99b8-11e9-8f3b-034f144d1ae0.png)

Test 2: 15 days, 12am to 12am on unmodified code, 12pm to 12pm on modified code. I_0 matches up, as expected, while surface temp starts off relatively different (as the unmodified code has had an extra 12 hours to run) but converges after both models have had some time to run.
![i_0_2](https://user-images.githubusercontent.com/26662438/60366003-3e506880-99b8-11e9-8bd0-0d02e1e91049.png)
![surface_temp_2](https://user-images.githubusercontent.com/26662438/60366011-3f819580-99b8-11e9-9933-67ee459ec125.png)

Test 3: 1 day, 12am to 12am on unmodified code, 12pm to 12pm on modified code. This is identical to the beginning of Test 2, but it shows clearly that I_0 matches up, even with the time difference.
![i_0_3](https://user-images.githubusercontent.com/26662438/60365978-35f82d80-99b8-11e9-9a2d-607475c91407.png)
![surface_temp_3](https://user-images.githubusercontent.com/26662438/60365985-37c1f100-99b8-11e9-939c-3422d89d5fe2.png)

We conclude that the changes I made seem to lead to correct results. I'm happy to answer questions or make any corrections.