### PR TITLE
fixed issue with refernce the 0th index of the z array

### DIFF
--- a/src/glm_aed2.F90
+++ b/src/glm_aed2.F90
@@ -937,15 +937,23 @@ SUBROUTINE calculate_fluxes(column, wlev, column_sed, nsed, flux_pel, flux_atm, 
       !# Disaggregation of zone induced fluxes to overlying layers
       v_start = 1 ; v_end = n_vars
       zon = n_zones
-      DO lev=wlev,2,-1
+      DO lev=wlev,1,-1
         IF ( zon .NE. 1 ) THEN
-          splitZone = zz(lev-1) < zone_heights(zon-1)
+        	IF(lev .GT. 1) THEN
+          		splitZone = zz(lev-1) < zone_heights(zon-1)
+          	ELSE
+          		splitZone = 0.0 < zone_heights(zon-1)
+          	ENDIF
         ELSE
           splitZone = .FALSE.
         ENDIF
 
         IF (splitZone) THEN
-          scale = (zone_heights(zon-1) - zz(lev-1)) / (zz(lev) - zz(lev-1))
+        	IF(lev .GT. 1) THEN
+        		scale = (zone_heights(zon-1) - zz(lev-1)) / (zz(lev) - zz(lev-1))
+        	ELSE
+        		scale = (zone_heights(zon-1) - 0.0) / (zz(lev) - 0.0)
+        	ENDIF
           flux_pel(lev,v_start:v_end) = flux_pel_z(zon,v_start:v_end) * scale
 
           zon = zon - 1

--- a/src/glm_aed2.F90
+++ b/src/glm_aed2.F90
@@ -937,7 +937,7 @@ SUBROUTINE calculate_fluxes(column, wlev, column_sed, nsed, flux_pel, flux_atm, 
       !# Disaggregation of zone induced fluxes to overlying layers
       v_start = 1 ; v_end = n_vars
       zon = n_zones
-      DO lev=wlev,1,-1
+      DO lev=wlev,2,-1
         IF ( zon .NE. 1 ) THEN
           splitZone = zz(lev-1) < zone_heights(zon-1)
         ELSE

--- a/src/glm_surface.c
+++ b/src/glm_surface.c
@@ -1093,8 +1093,13 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
             for (i = botmLayer; i <= surfLayer; i++) {
                 layer_zone[i] = 0;
                 for (z = 0; z < n_zones; z++) {
-                    if (Lake[i].Height<zone_heights[z] && Lake[i].Height>zone_heights[z-1])
-                        layer_zone[i] = z;
+                	if(z == 0){
+                		if (Lake[i].Height<zone_heights[z] && Lake[i].Height>0.0)
+                        	layer_zone[i] = z;
+                    }else{
+                		if (Lake[i].Height<zone_heights[z] && Lake[i].Height>zone_heights[z-1])
+                        	layer_zone[i] = z;
+                	}
                 }
             }
             //# Now compute layer-specifc sed heating and increment temperature

--- a/src/glm_zones.F90
+++ b/src/glm_zones.F90
@@ -217,15 +217,23 @@ SUBROUTINE copy_from_zone(x_cc, x_diag, x_diag_hz, wlev)
    v_start = nvars+1 ; v_end = nvars+nbenv
 
    zon = n_zones
-   DO lev=wlev,2,-1
+   DO lev=wlev,1,-1
       IF ( zon .NE. 1 ) THEN
-         splitZone = zz(lev-1) < zone_heights(zon-1)
+      		IF(lev .GT. 1) THEN
+          		splitZone = zz(lev-1) < zone_heights(zon-1)
+          	ELSE
+           		splitZone = 0.0 < zone_heights(zon-1)
+          	ENDIF
       ELSE
          splitZone = .FALSE.
       ENDIF
 
       IF (splitZone) THEN
-         scale = (zone_heights(zon-1) - zz(lev-1)) / (zz(lev) - zz(lev-1))
+         IF(lev .GT. 1) THEN
+          	scale = (zone_heights(zon-1) - zz(lev-1)) / (zz(lev) - zz(lev-1))
+          ELSE
+          	scale = (zone_heights(zon-1) - 0.0) / (zz(lev) - 0.0)
+          ENDIF
          WHERE(z_diag(zon,:) /= 0.) &
             x_diag(lev,:) = z_diag(zon,:) * scale
          x_cc(lev,v_start:v_end) = z_cc(zon,v_start:v_end) * scale

--- a/src/glm_zones.F90
+++ b/src/glm_zones.F90
@@ -217,7 +217,7 @@ SUBROUTINE copy_from_zone(x_cc, x_diag, x_diag_hz, wlev)
    v_start = nvars+1 ; v_end = nvars+nbenv
 
    zon = n_zones
-   DO lev=wlev,1,-1
+   DO lev=wlev,2,-1
       IF ( zon .NE. 1 ) THEN
          splitZone = zz(lev-1) < zone_heights(zon-1)
       ELSE


### PR DESCRIPTION
I was getting segmentation faults randomly with AED turned on. After looking into it, it appears that the code was trying to use the 0th index of the heights array. In some lucky runs zz(0) was set to zero but in unlucky runs zz(0) was not an integer - resulting in a sedimentation fault. Since the code is looking down the heights it seems that it wants stop the DO loop at 2 so that the last time through it looks down to the bottom height (i.e., the one with 1th index).