### PR TITLE
Initialize with ice and snow values

### DIFF
--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1284,6 +1284,9 @@ void initialise_lake(int namlst)
     int             num_wq_vars;
     char          **wq_names;
     AED_REAL       *wq_init_vals;
+    AED_REAL        snow_height;
+    AED_REAL        white_ice_height;
+    AED_REAL        blue_ice_height;
     /*-------------------------------------------*/
 
     NAMELIST init_profiles[] = {
@@ -1298,6 +1301,9 @@ void initialise_lake(int namlst)
           { "num_wq_vars",       TYPE_INT,              &num_wq_vars       },
           { "wq_names",          TYPE_STR|MASK_LIST,    &wq_names          },
           { "wq_init_vals",      TYPE_DOUBLE|MASK_LIST, &wq_init_vals      },
+          { "snow_height", 		 TYPE_DOUBLE,			&snow_height	   },
+          { "white_ice_height",  TYPE_DOUBLE,		    &white_ice_height  },
+          { "blue_ice_height", 	 TYPE_DOUBLE,		    &blue_ice_height   },
           { NULL,                TYPE_END,              NULL               }
     };
 
@@ -1420,9 +1426,15 @@ void initialise_lake(int namlst)
         Lake[offshoreLayer].Temp = Lake[surfLayer].Temp;
     }
 
+    SurfData.delzWhiteIce = white_ice_height;
+    SurfData.delzBlueIce = blue_ice_height;
+    
+    //Initializing with non-zero snow height causes segmentation faults
     SurfData.delzSnow = zero;
-    SurfData.delzWhiteIce = zero;
-    SurfData.delzBlueIce = zero;
+    
+    if(SurfData.delzBlueIce > 0.0 || SurfData.delzWhiteIce > 0.0){
+      ice = TRUE;
+    }
 
 }
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1284,9 +1284,9 @@ void initialise_lake(int namlst)
     int             num_wq_vars;
     char          **wq_names;
     AED_REAL       *wq_init_vals;
-    AED_REAL        snow_height;
-    AED_REAL        white_ice_height;
-    AED_REAL        blue_ice_height;
+    AED_REAL        snow_thickness;
+    AED_REAL        white_ice_thickness;
+    AED_REAL        blue_ice_thickness;
     /*-------------------------------------------*/
 
     NAMELIST init_profiles[] = {
@@ -1301,9 +1301,9 @@ void initialise_lake(int namlst)
           { "num_wq_vars",       TYPE_INT,              &num_wq_vars       },
           { "wq_names",          TYPE_STR|MASK_LIST,    &wq_names          },
           { "wq_init_vals",      TYPE_DOUBLE|MASK_LIST, &wq_init_vals      },
-          { "snow_height", 		 TYPE_DOUBLE,			&snow_height	   },
-          { "white_ice_height",  TYPE_DOUBLE,		    &white_ice_height  },
-          { "blue_ice_height", 	 TYPE_DOUBLE,		    &blue_ice_height   },
+          { "snow_thickness", 		 TYPE_DOUBLE,		&snow_thickness	   },
+          { "white_ice_thickness",  TYPE_DOUBLE,		&white_ice_thickness  },
+          { "blue_ice_thickness", 	 TYPE_DOUBLE,		&blue_ice_thickness   },
           { NULL,                TYPE_END,              NULL               }
     };
 
@@ -1426,10 +1426,10 @@ void initialise_lake(int namlst)
         Lake[offshoreLayer].Temp = Lake[surfLayer].Temp;
     }
 
-    SurfData.delzWhiteIce = white_ice_height;
-    SurfData.delzBlueIce = blue_ice_height;
+    SurfData.delzWhiteIce = white_ice_thickness;
+    SurfData.delzBlueIce = blue_ice_thickness;
     
-    //Initializing with non-zero snow height causes segmentation faults
+    //Initializing with non-zero snow thickness causes segmentation faults
     SurfData.delzSnow = zero;
     
     if(SurfData.delzBlueIce > 0.0 || SurfData.delzWhiteIce > 0.0){


### PR DESCRIPTION
I added code that initializes the snow, blue ice, and white ice thickness.  This "hot start" is required for data assimilation applications.  Some comments:

1) Initializing with non-zero values for snow thickness causes segmentation faults
2) This implementation requires values for the three thicknesses.  Therefore the glm3.nml must have values for snow_thickness, white_ice_thickness, blue_ice_thickness.  This would required an update to all the example glm3.nmls.  We may want to make these values optional (and default to zero if not provided) but I am not sure how best to do that.