### PR TITLE
Allows restart of AvgSurfTemp variable

### DIFF
--- a/src/glm_globals.h
+++ b/src/glm_globals.h
@@ -67,7 +67,7 @@ extern int ncid;
 
 /* from glm_surf.F90 */
 extern int ice;
-
+extern AED_REAL AvgSurfTemp;
 /*----------------------------------------------------------------------------*/
 extern int MaxLayers;   //# Maximum number of layers in this sim
 extern int NumLayers;   //# current number of layers

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1319,6 +1319,7 @@ void initialise_lake(int namlst)
     AED_REAL        snow_thickness = 0.0;
     AED_REAL        white_ice_thickness = 0.0;
     AED_REAL        blue_ice_thickness = 0.0;
+    AED_REAL        avg_surf_temp = 6.0;
 
     //==========================================================================
     NAMELIST init_profiles[] = {
@@ -1334,8 +1335,9 @@ void initialise_lake(int namlst)
           { "wq_names",            TYPE_STR|MASK_LIST,    &wq_names           },
           { "wq_init_vals",        TYPE_DOUBLE|MASK_LIST, &wq_init_vals       },
           { "snow_thickness",      TYPE_DOUBLE,           &snow_thickness     },
-          { "white_ice_thickness", TYPE_DOUBLE,           &white_ice_thickness },
+          { "white_ice_thickness", TYPE_DOUBLE,           &white_ice_thickness},
           { "blue_ice_thickness",  TYPE_DOUBLE,           &blue_ice_thickness },
+          { "avg_surf_temp",       TYPE_DOUBLE,           &avg_surf_temp      },
           { NULL,                  TYPE_END,              NULL                }
     };
     /*-- %%END NAMELIST ------------------------------------------------------*/
@@ -1468,6 +1470,8 @@ void initialise_lake(int namlst)
     if (SurfData.delzBlueIce > 0.0 || SurfData.delzWhiteIce > 0.0) {
         ice = TRUE;
     }
+    
+    AvgSurfTemp = avg_surf_temp;
 }
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 

--- a/src/glm_ncdf.c
+++ b/src/glm_ncdf.c
@@ -55,7 +55,7 @@ static size_t start[4],edges[4];
 
 //# variable ids
 static int lon_id,lat_id,z_id,V_id,TV_id,Taub_id,NS_id,time_id;
-static int HICE_id,HSNOW_id,HWICE_id;
+static int HICE_id,HSNOW_id,HWICE_id, AvgSurfTemp_id;
 static int precip_id,evap_id,rho_id,rad_id,extc_id,i0_id,wnd_id;
 static int temp_id, salt_id, umean_id, uorb_id;
 
@@ -107,6 +107,7 @@ int init_glm_ncdf(const char *fn, const char *title, AED_REAL lat,
     check_nc_error(nc_def_var(ncid, "hice",  NC_REALTYPE, 1, dims, &HICE_id));
     check_nc_error(nc_def_var(ncid, "hsnow", NC_REALTYPE, 1, dims, &HSNOW_id));
     check_nc_error(nc_def_var(ncid, "hwice", NC_REALTYPE, 1, dims, &HWICE_id));
+    check_nc_error(nc_def_var(ncid, "avg_surf_temp", NC_REALTYPE, 1, dims, &AvgSurfTemp_id));
 
     /**************************************************************************
      * define variables                                                       *
@@ -157,6 +158,7 @@ int init_glm_ncdf(const char *fn, const char *title, AED_REAL lat,
     set_nc_attributes(ncid, HICE_id,   "meters",  "Height of Ice"   PARAM_FILLVALUE);
     set_nc_attributes(ncid, HSNOW_id,  "meters",  "Height of Snow"  PARAM_FILLVALUE);
     set_nc_attributes(ncid, HWICE_id,  "meters",  "Height of WhiteIce" PARAM_FILLVALUE);
+     set_nc_attributes(ncid, AvgSurfTemp_id,  "celsius",  "Running average surface temperature" PARAM_FILLVALUE);
 
     //# x,y,t
     set_nc_attributes(ncid, precip_id, "m/s",     "precipitation"   PARAM_FILLVALUE);
@@ -229,6 +231,7 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
     store_nc_scalar(ncid,  HICE_id, T_SHAPE, SurfData.delzBlueIce);
     store_nc_scalar(ncid, HWICE_id, T_SHAPE, SurfData.delzWhiteIce);
     store_nc_scalar(ncid, HSNOW_id, T_SHAPE, SurfData.delzSnow);
+    store_nc_scalar(ncid, AvgSurfTemp_id, T_SHAPE, AvgSurfTemp);
 
     store_nc_scalar(ncid, precip_id, XYT_SHAPE, MetData.Rain);
     store_nc_scalar(ncid,   evap_id, XYT_SHAPE, SurfData.Evap);

--- a/src/glm_surface.c
+++ b/src/glm_surface.c
@@ -88,6 +88,7 @@ int  atmos_stability(     AED_REAL *Q_latentheat,
  ******************************************************************************/
 
 int ice = FALSE;               // flag that tells if there is ice cover
+AED_REAL  AvgSurfTemp= 6.;  // Recent average of surface temp, for ice-on.
 
 // Heat fluxes; these are made available for the lake.csv output
 AED_REAL zonL;                 // average z/L - MO atmospheric stability
@@ -102,7 +103,6 @@ static AED_REAL  Q_icewater;   // Heat flux across water/ice interface
 static AED_REAL  Q_surflayer;  // Heat flux through the water surface
 static AED_REAL  Q_underflow;  // Heat flux through water due to flow under the ice
 //static AED_REAL  U_flow;     // Velocity estimate of the underflow
-static AED_REAL  AvgSurfTemp= 6.;  // Recent average of surface temp, for ice-on.
 
 static AED_REAL  snow_rain_compact = 1. ; //update based on timestep and scaling
 


### PR DESCRIPTION
AvgSurfTemp is a running average of surface temperature that is set to 6 when a model simulation starts.  In order to do a restart for data assimilation, this variable needs to be able to be read in from the glm3.nml file and included as output in the output.nc file.  This pull request does this. It should allow for the avg_surf_temp variable in the init_profiles part of the glm3.nml to be optional (which is the preferred behavior).  