### PR TITLE
adding mixing restart variables

### DIFF
--- a/src/glm.h
+++ b/src/glm.h
@@ -43,6 +43,7 @@
 #define XYT_SHAPE     4
 #define XYZT_SHAPE    5
 #define XYNT_SHAPE    6
+#define R_SHAPE       1
 
 #define PATH_MAX  1024
 

--- a/src/glm_globals.h
+++ b/src/glm_globals.h
@@ -199,6 +199,31 @@ extern AED_REAL albedo_amplitude;   //#  albedo seasonal amplitude
 extern AED_REAL lw_factor ;
 extern AED_REAL lw_offset ;
 
+//# DepMX is the layer height of the meta top on the previous timestep.
+extern AED_REAL DepMX;
+
+extern AED_REAL PrevThick;   //# mixed layer thickness from previous time step
+
+extern AED_REAL gPrimeTwoLayer;  //# Reduced gravity for int wave estimate
+
+extern AED_REAL Energy_AvailableMix;  //# Total available energy to mix (carries over from previous timesteps)
+
+extern AED_REAL Mass_Epi; //# Sigma mass of Epilimnion (surface layer after Kelvin-Helmholtz) kg
+
+extern AED_REAL OldSlope;
+extern AED_REAL Time_end_shear;  //# Time left before shear cut off [hours]
+extern AED_REAL Time_start_shear; //# Time count since start of sim for shear period start [hours]
+extern AED_REAL Time_count_end_shear;  //# Time count since start of sim for shear period end [hours]
+extern AED_REAL Time_count_sim;  //# Time count since start of simulation [hours]
+
+extern AED_REAL Half_Seiche_Period; //# One half the seiche period
+extern AED_REAL Thermocline_Height; //# Height at the top of the metalimnion [m]
+extern AED_REAL FO;
+extern AED_REAL FSUM;
+extern AED_REAL u_f;
+extern AED_REAL u0;
+extern AED_REAL u_avg;
+
 /*----------------------------------------------------------------------------*/
 // SNOWICE
 extern AED_REAL snow_albedo_factor;

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1358,6 +1358,7 @@ void initialise_lake(int namlst)
     AED_REAL        white_ice_thickness = 0.0;
     AED_REAL        blue_ice_thickness = 0.0;
     AED_REAL        avg_surf_temp = 6.0;
+    AED_REAL		*restart_variables;
 
     //==========================================================================
     NAMELIST init_profiles[] = {
@@ -1376,6 +1377,7 @@ void initialise_lake(int namlst)
           { "white_ice_thickness", TYPE_DOUBLE,           &white_ice_thickness},
           { "blue_ice_thickness",  TYPE_DOUBLE,           &blue_ice_thickness },
           { "avg_surf_temp",       TYPE_DOUBLE,           &avg_surf_temp      },
+          { "restart_variables",   TYPE_DOUBLE|MASK_LIST, &restart_variables  },
           { NULL,                  TYPE_END,              NULL                }
     };
     /*-- %%END NAMELIST ------------------------------------------------------*/
@@ -1383,6 +1385,9 @@ void initialise_lake(int namlst)
     int i, j, min_layers;
     int nx, np, nz;
     int *idx = NULL;
+    
+    restart_variables = calloc(17, sizeof(AED_REAL));
+    restart_variables[0] = MISVAL;
 
 /*----------------------------------------------------------------------------*/
     //-------------------------------------------------
@@ -1392,10 +1397,12 @@ void initialise_lake(int namlst)
     num_depths = 0;
     lake_depth = MISVAL;
     num_wq_vars = 0;
+         
     if ( get_namelist(namlst, init_profiles) ) {
         fprintf(stderr,"     ERROR: reading initial_profiles from namelist file %s\n", glm_nml_file);
         exit(1);
     }
+    
     if (! wq_calc) num_wq_vars = 0;
 
     // Initial values for the number of levels specified in the glm.nml file
@@ -1510,6 +1517,31 @@ void initialise_lake(int namlst)
     }
 
     AvgSurfTemp = avg_surf_temp;
+    
+   
+    if(restart_variables[0] != MISVAL){
+    	DepMX = restart_variables[0];
+    	PrevThick =  restart_variables[1]; //# mixed layer thickness from previous time step
+    	gPrimeTwoLayer =  restart_variables[2]; //# Reduced gravity for int wave estimate
+    	Energy_AvailableMix = restart_variables[3];  //# Total available energy to mix (carries over from previous timesteps)
+    	Mass_Epi =  restart_variables[4];//# Sigma mass of Epilimnion (surface layer after Kelvin-Helmholtz) kg
+    	OldSlope = restart_variables[5];
+    	Time_end_shear =  restart_variables[6]; //# Time left before shear cut off [hours]
+    	Time_start_shear =  restart_variables[7];//# Time count since start of sim for shear period start [hours]
+    	Time_count_end_shear =  restart_variables[8]; //# Time count since start of sim for shear period end [hours]
+    	Time_count_sim = restart_variables[9];  //# Time count since start of simulation [hours]
+    	Half_Seiche_Period = restart_variables[10];//# One half the seiche period
+    	Thermocline_Height =  restart_variables[11];//# Height at the top of the metalimnion [m]
+    	FO = restart_variables[12];
+    	FSUM = restart_variables[13];
+    	u_f = restart_variables[14];
+    	u0 = restart_variables[15];
+    	u_avg = restart_variables[16];
+    }
+    
+    
+    free(restart_variables);
+    
 }
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 

--- a/src/glm_mixer.c
+++ b/src/glm_mixer.c
@@ -66,33 +66,33 @@
 /*============================================================================*/
 
 //# DepMX is the layer height of the meta top on the previous timestep.
-static   AED_REAL DepMX   = 0.;
+AED_REAL DepMX   = 0.;
 
-static   AED_REAL Epi_dz;     //# Thickness of epilimnion [m]
-static   AED_REAL MeanSalt;   //# MeanSalt ... mean salinity
-static   AED_REAL MeanTemp;   //# MeanTemp ... mass averaged mean temperature of epilimnion
+AED_REAL Epi_dz;     //# Thickness of epilimnion [m]
+AED_REAL MeanSalt;   //# MeanSalt ... mean salinity
+AED_REAL MeanTemp;   //# MeanTemp ... mass averaged mean temperature of epilimnion
 
-static   AED_REAL PrevThick = 0.;   //# mixed layer thickness from previous time step
+AED_REAL PrevThick = 0.;   //# mixed layer thickness from previous time step
 
-static   AED_REAL gPrimeTwoLayer = 0.;  //# Reduced gravity for int wave estimate
+AED_REAL gPrimeTwoLayer = 0.;  //# Reduced gravity for int wave estimate
 
-static   AED_REAL Energy_AvailableMix = 0.;  //# Total available energy to mix (carries over from previous timesteps)
+AED_REAL Energy_AvailableMix = 0.;  //# Total available energy to mix (carries over from previous timesteps)
 
-static   AED_REAL Mass_Epi = 0.; //# Sigma mass of Epilimnion (surface layer after Kelvin-Helmholtz) kg
+AED_REAL Mass_Epi = 0.; //# Sigma mass of Epilimnion (surface layer after Kelvin-Helmholtz) kg
 
-static   AED_REAL OldSlope   = 0.;
-static   AED_REAL Time_end_shear   = 0.;  //# Time left before shear cut off [hours]
-static   AED_REAL Time_start_shear = 0.;  //# Time count since start of sim for shear period start [hours]
-static   AED_REAL Time_count_end_shear = 0.;  //# Time count since start of sim for shear period end [hours]
-static   AED_REAL Time_count_sim     = 0.;  //# Time count since start of simulation [hours]
+AED_REAL OldSlope   = 0.;
+AED_REAL Time_end_shear   = 0.;  //# Time left before shear cut off [hours]
+AED_REAL Time_start_shear = 0.;  //# Time count since start of sim for shear period start [hours]
+AED_REAL Time_count_end_shear = 0.;  //# Time count since start of sim for shear period end [hours]
+AED_REAL Time_count_sim     = 0.;  //# Time count since start of simulation [hours]
 
-static   AED_REAL Half_Seiche_Period = 0.; //# One half the seiche period
-static   AED_REAL Thermocline_Height = 0.; //# Height at the top of the metalimnion [m]
-static   AED_REAL FO      = 0.;
-static   AED_REAL FSUM    = 0.;
-static   AED_REAL u_f     = 0.;
-static   AED_REAL u0      = 0.;
-static   AED_REAL u_avg   = 0.;
+AED_REAL Half_Seiche_Period = 0.; //# One half the seiche period
+AED_REAL Thermocline_Height = 0.; //# Height at the top of the metalimnion [m]
+AED_REAL FO      = 0.;
+AED_REAL FSUM    = 0.;
+AED_REAL u_f     = 0.;
+AED_REAL u0      = 0.;
+AED_REAL u_avg   = 0.;
 
 //# Wind parameters
 static AED_REAL WindSpeedX;  //# Actual wind speed, accounting for wind factor or ice [m s-1]

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -174,7 +174,7 @@ void init_model(int *jstart, int *nsave)
     //# Check layers for vmax,vmin
     check_layer_thickness();
 
-    init_mixer();
+    if(DepMX == 0.0) init_mixer();
 
     Latitude = two_Pi + Latitude * deg2rad; //# Convert latitude from degrees to radians
 }

--- a/src/glm_ncdf.c
+++ b/src/glm_ncdf.c
@@ -274,8 +274,8 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
 	restart_variables[12] = FO;
 	restart_variables[13] = FSUM;
 	restart_variables[14] = u_f;
-	restart_variables[16] = u0;
-	restart_variables[17] = u_avg;
+	restart_variables[15] = u0;
+	restart_variables[16] = u_avg;
 	 
     start_r[0] = 0; edges_r[0] = restart_len;
 	

--- a/src/glm_ncdf.c
+++ b/src/glm_ncdf.c
@@ -44,20 +44,23 @@ int ncid=-1;
 static int set_no = -1;
 
 //# dimension sizes
-int x_dim, y_dim, z_dim, zone_dim, time_dim;
+int x_dim, y_dim, z_dim, zone_dim, time_dim, restart_dim;
 
 //# dimension lengths
 static int lon_len=1;
 static int lat_len=1;
 static int height_len;
+static int restart_len = 17;
 
 static size_t start[4],edges[4];
+
+static size_t start_r[1],edges_r[1];
 
 //# variable ids
 static int lon_id,lat_id,z_id,V_id,TV_id,Taub_id,NS_id,time_id;
 static int HICE_id,HSNOW_id,HWICE_id, AvgSurfTemp_id;
 static int precip_id,evap_id,rho_id,rad_id,extc_id,i0_id,wnd_id;
-static int temp_id, salt_id, umean_id, uorb_id;
+static int temp_id, salt_id, umean_id, uorb_id, restart_id;
 
 #ifdef _WIN32
     char *strndup(const char *s, size_t len);
@@ -90,6 +93,7 @@ int init_glm_ncdf(const char *fn, const char *title, AED_REAL lat,
     check_nc_error(nc_def_dim(ncid, "lon", 1, &x_dim));
     check_nc_error(nc_def_dim(ncid, "lat", 1, &y_dim));
     check_nc_error(nc_def_dim(ncid, "z", nlev, &z_dim));
+    check_nc_error(nc_def_dim(ncid, "restart", 17, &restart_dim));
     if ( n_zones > 0 )
         check_nc_error(nc_def_dim(ncid, "nzones", n_zones, &zone_dim));
     check_nc_error(nc_def_dim(ncid, "time", NC_UNLIMITED, &time_dim));
@@ -108,11 +112,14 @@ int init_glm_ncdf(const char *fn, const char *title, AED_REAL lat,
     check_nc_error(nc_def_var(ncid, "hsnow", NC_REALTYPE, 1, dims, &HSNOW_id));
     check_nc_error(nc_def_var(ncid, "hwice", NC_REALTYPE, 1, dims, &HWICE_id));
     check_nc_error(nc_def_var(ncid, "avg_surf_temp", NC_REALTYPE, 1, dims, &AvgSurfTemp_id));
+    
+    dims[0] = restart_dim;
+    check_nc_error(nc_def_var(ncid, "restart_variables", NC_REALTYPE, 1, dims, &restart_id));
 
     /**************************************************************************
      * define variables                                                       *
      **************************************************************************/
-
+     
     //# x,y,t
     dims[2] = x_dim;
     dims[1] = y_dim;
@@ -159,6 +166,12 @@ int init_glm_ncdf(const char *fn, const char *title, AED_REAL lat,
     set_nc_attributes(ncid, HSNOW_id,  "meters",  "Height of Snow"  PARAM_FILLVALUE);
     set_nc_attributes(ncid, HWICE_id,  "meters",  "Height of WhiteIce" PARAM_FILLVALUE);
      set_nc_attributes(ncid, AvgSurfTemp_id,  "celsius",  "Running average surface temperature" PARAM_FILLVALUE);
+     
+    set_nc_attributes(ncid, restart_id,  "various",  "dep_mx,prev_thick,g_prime_two_layer,\
+    energy_avail_max,mass_epi,old_slope,time_end_shear,time_start_shear,\
+    time_count_end,time_count_sim,half_seiche_period,thermocline_height,\
+    f0, fsum,u_f,u0,u_avg" PARAM_FILLVALUE);
+
 
     //# x,y,t
     set_nc_attributes(ncid, precip_id, "m/s",     "precipitation"   PARAM_FILLVALUE);
@@ -213,7 +226,7 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
 {
     AED_REAL temp_time, LakeVolume;
     AED_REAL *heights, *vols, *salts, *temps, *dens, *qsw, *extc_coef;
-    AED_REAL *u_mean, *u_orb, *taub;
+    AED_REAL *u_mean, *u_orb, *taub, *restart_variables;
     int i, littoralLayer = 0;
 
     set_no++;
@@ -240,7 +253,34 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
     store_nc_scalar(ncid, wnd_id, XYT_SHAPE, MetData.WindSpeed);
 
     store_nc_scalar(ncid,  TV_id, XYT_SHAPE, LakeVolume);
+    
+    
+    //# Restart variables
+    /*------------------------------------------------------------------------*/
 
+    restart_variables   = malloc(17*sizeof(AED_REAL));
+    restart_variables[0] = DepMX;
+	restart_variables[1] = PrevThick;
+	restart_variables[2] = gPrimeTwoLayer;
+	restart_variables[3] = Energy_AvailableMix;
+	restart_variables[4] = Mass_Epi;
+	restart_variables[5] = OldSlope;
+	restart_variables[6] = Time_end_shear;
+	restart_variables[7] = Time_start_shear;
+	restart_variables[8] = Time_count_end_shear;
+	restart_variables[9] = Time_count_sim;
+	restart_variables[10] = Half_Seiche_Period;
+	restart_variables[11] = Thermocline_Height;
+	restart_variables[12] = FO;
+	restart_variables[13] = FSUM;
+	restart_variables[14] = u_f;
+	restart_variables[16] = u0;
+	restart_variables[17] = u_avg;
+	 
+    start_r[0] = 0; edges_r[0] = restart_len;
+	
+	//store_nc_scalar(ncid,  restart_id, R_SHAPE, restart_variables);
+    check_nc_error(nc_put_vara(ncid,  restart_id, start_r, edges_r, restart_variables));
 
     //# Time varying profile data : z,t
     /*------------------------------------------------------------------------*/
@@ -297,7 +337,7 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
         u_orb[littoralLayer] = NC_FILLER;
         taub[littoralLayer] = NC_FILLER;
     }
-
+    
     check_nc_error(nc_put_vara(ncid,     z_id, start, edges, heights));
     check_nc_error(nc_put_vara(ncid,     V_id, start, edges, vols));
     check_nc_error(nc_put_vara(ncid,  salt_id, start, edges, salts));
@@ -312,7 +352,7 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
     free(heights); free(vols); free(salts);
     free(temps);  free(dens); free(qsw);
     free(extc_coef); free(u_mean); free(u_orb);
-    free(taub);
+    free(taub); free(restart_variables);
 
     check_nc_error(nc_sync(ncid));
 }


### PR DESCRIPTION
I added the mixing restart variables that I mentioned in an Issue.  First, I added an optional variable to the init_profiles nml section that is the 17 mixing variables that need initial values.  It is optional because it will be rare that a user will specify the values in the nml but they are necessary for an accurate restart.  Second, I  added a vector of the 17 variables to the netcdf output.  It is designed so that you use the same order of the netcdf output as the order in the nml. 