### PR TITLE
adding new ice temp threshold parameter

### DIFF
--- a/src/glm_globals.c
+++ b/src/glm_globals.c
@@ -193,6 +193,7 @@ AED_REAL rho_ice_blue = 917.0;        //# density of blue ice
 AED_REAL rho_ice_white = 890.0;       //# density of white ice
 AED_REAL min_ice_thickness = 0.05;    //# threshold thickness for new ice-on, or ice-off
 AED_REAL dt_iceon_avg = 0.5;          //# moving average time-scale of water temp to identify ice-on transition
+AED_REAL avg_surf_temp_thres = 0.0;
 
 //------------------------------------------------------------------------------
 // SEDIMENT

--- a/src/glm_globals.h
+++ b/src/glm_globals.h
@@ -245,6 +245,7 @@ extern AED_REAL  rho_ice_blue;
 extern AED_REAL  rho_ice_white;
 extern AED_REAL  min_ice_thickness;
 extern AED_REAL  dt_iceon_avg;
+extern AED_REAL avg_surf_temp_thres;
 
 /*----------------------------------------------------------------------------*/
 // SEDIMENT

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -451,6 +451,7 @@ void init_glm(int *jstart, char *outp_dir, char *outp_fn, int *nsave)
     extern AED_REAL rho_ice_white;
     extern AED_REAL min_ice_thickness;
     extern AED_REAL dt_iceon_avg;
+    extern AED_REAL avg_surf_temp_thres;
 
     //==========================================================================
     NAMELIST snowice[] = {
@@ -475,6 +476,7 @@ void init_glm(int *jstart, char *outp_dir, char *outp_fn, int *nsave)
           { "rho_ice_white",         TYPE_DOUBLE,       &rho_ice_white        },
           { "min_ice_thickness",     TYPE_DOUBLE,       &min_ice_thickness    },
           { "dt_iceon_avg",          TYPE_DOUBLE,       &dt_iceon_avg         },
+          { "avg_surf_temp_thres",   TYPE_DOUBLE,       &avg_surf_temp_thres  },
           { NULL,                    TYPE_END,          NULL                  }
     };
     /*-- %%END NAMELIST ------------------------------------------------------*/

--- a/src/glm_surface.c
+++ b/src/glm_surface.c
@@ -1209,7 +1209,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
     AvgSurfTemp = AvgSurfTemp * (1 - (noSecs/SecsPerDay)/dt_ice_avg)
                        + Lake[surfLayer].Temp * (noSecs/SecsPerDay)/dt_ice_avg ;
 
-    if (AvgSurfTemp <= 0.0 && SurfData.delzBlueIce == 0.0 && Lake[surfLayer].Height>0.1) {
+    if (AvgSurfTemp <= avg_surf_temp_thres && SurfData.delzBlueIce == 0.0 && Lake[surfLayer].Height>0.1) {
         // Start a new blue ice layer
         ice                     = TRUE;
         SurfData.delzBlueIce    = min_ice_thickness; //0.05;


### PR DESCRIPTION
This PR adds a parameter that allows the user to adjust the temperature threshold where ice starts to form.   The value was hard coded to 0.0 which is still the default.  We found that we could not get ice to form at FCR with a value of 0.0 but setting to 0.1 allowed ice to form when expected.  This parameter could represent an offset in surface temperature between cold parts of a lake (where ice forms first) and the mean conditions of the lake.  