### PR TITLE
fixing ice issue

### DIFF
--- a/src/glm_surface.c
+++ b/src/glm_surface.c
@@ -995,6 +995,24 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
         Lake[onshoreLayer].Temp += dTemp;
     }
 
+      /**************************************************************************
+     * Check if the ice melted in code above
+     *************************************************************************/
+    if ((SurfData.delzBlueIce+SurfData.delzWhiteIce) < min_ice_thickness && ice) {
+      Lake[surfLayer].Height = Lake[surfLayer].Height
+      + SurfData.delzBlueIce  * (rho_ice_blue/Lake[surfLayer].Density)
+      + SurfData.delzWhiteIce * (rho_ice_white/Lake[surfLayer].Density)
+      + SurfData.delzSnow     * (rho_snow/Lake[surfLayer].Density);
+      
+      recalc_surface_salt();
+      
+      ice = FALSE;
+      SurfData.delzBlueIce  = 0.0;
+      SurfData.delzWhiteIce = 0.0;
+      SurfData.delzSnow    = 0.0;
+    }
+
+
     /***************************************************************************
      * ICE MELTING & FREEZING @ BOTTOM
      * The change in ice thickness at the bottom can now be determined


### PR DESCRIPTION
@matthipsey @casper-boon if you approve of the PR it would be great to have it in the glm-aed build so that we can use that version.  We are currently needing to compile glm-aed ourselves to handle this issue at Falling Creek Reservoir.  

SurfData.delzBlueIce can be zero after the code above but the ice flag hasn't been updated. As a result, the code still has ice=TRUE and enters the if statement around line 1017. Then it calculates the following

```
EEE = (K_snow*K_ice_white*K_ice_blue)/((SurfData.delzSnow*K_ice_white*K_ice_blue)+(SurfData.delzBlueIce*K_snow*K_ice_blue)+
                                       (SurfData.delzWhiteIce*K_snow*K_ice_white));
```
which evaluates to inf and causes NaN in surface temperatures.

