### PR TITLE
Updates to improve restart capacity

### DIFF
--- a/src/glm_deep.c
+++ b/src/glm_deep.c
@@ -518,7 +518,7 @@ void check_layer_stability()
     while (surfLayer != botmLayer) {
         //# find an unstable layer configuration (instability)
         for (k = surfLayer; k >= (botmLayer+1); k--)
-            if (Lake[k].Density > Lake[k-1].Density) break;
+            if ((Lake[k].Density - Lake[k-1].Density) >  1e-4) break;
 
         if (k < (botmLayer+1)) return ;
 

--- a/src/glm_globals.h
+++ b/src/glm_globals.h
@@ -226,6 +226,9 @@ extern AED_REAL FSUM;
 extern AED_REAL u_f;
 extern AED_REAL u0;
 extern AED_REAL u_avg;
+extern int Mixer_Count;
+
+
 
 /*----------------------------------------------------------------------------*/
 // SNOWICE

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1512,6 +1512,8 @@ void initialise_lake(int namlst)
     AED_REAL        blue_ice_thickness = 0.0;
     AED_REAL        avg_surf_temp = 6.0;
     AED_REAL       *restart_variables = NULL;
+    int			   restart_mixer_count;
+    
 
     //==========================================================================
     NAMELIST init_profiles[] = {
@@ -1531,6 +1533,7 @@ void initialise_lake(int namlst)
           { "blue_ice_thickness",  TYPE_DOUBLE,           &blue_ice_thickness },
           { "avg_surf_temp",       TYPE_DOUBLE,           &avg_surf_temp      },
           { "restart_variables",   TYPE_DOUBLE|MASK_LIST, &restart_variables  },
+          { "restart_mixer_count",  TYPE_INT		, &restart_mixer_count},
           { NULL,                  TYPE_END,              NULL                }
     };
     /*-- %%END NAMELIST ------------------------------------------------------*/
@@ -1673,6 +1676,12 @@ void initialise_lake(int namlst)
     if (SurfData.delzBlueIce > 0.0 || SurfData.delzWhiteIce > 0.0) {
         ice = TRUE;
     }
+    
+    if (deep_mixing == 1) {      //constant diffusivity over whole water column
+        for (i = 0; i < NumLayers; i++)
+          Lake[i].Epsilon = coef_mix_hyp;
+    }
+    
 
     AvgSurfTemp = avg_surf_temp;
 
@@ -1694,9 +1703,12 @@ void initialise_lake(int namlst)
         u_f = restart_variables[14];
         u0 = restart_variables[15];
         u_avg = restart_variables[16];
+        
+        Mixer_Count = restart_mixer_count;
 
         free(restart_variables);
     }
+    
 }
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1564,7 +1564,7 @@ void initialise_lake(int namlst)
             Lake[i].Salinity = the_sals[i];
         }
 
-        if (the_heights[num_depths-1] > CrestHeight) {
+        if (the_heights[num_heights-1] > CrestHeight) {
             fprintf(stderr, "     ERROR: maximum height is greater than crest level\n");
             exit(1);
         }

--- a/src/glm_layers.c
+++ b/src/glm_layers.c
@@ -108,7 +108,7 @@ void check_layer_thickness(void)
                  DELDP = Lake[i].Height;
             else
                  DELDP = Lake[i].Height - Lake[i-1].Height;
-            if ((VMin - Lake[i].LayerVol) > 1e-4 && (DMin - DELDP) > 1e-4) break;
+            if ((VMin - Lake[i].LayerVol) > 1e-7 && (DMin - DELDP) > 1e-7) break;
         }
 
         if (i > surfLayer) break;
@@ -190,7 +190,7 @@ void check_layer_thickness(void)
 
             if (i == surfLayer) VSUMCHK = TRUE;
 
-             if ((Lake[i].LayerVol-VMax) > 1e-4 || (DELDP - DMax) > 1e-4) break;
+             if ((Lake[i].LayerVol-VMax) > 1e-7 || (DELDP - DMax) > 1e-7) break;
         }
 
         // return to calling program when all layers have been checked

--- a/src/glm_layers.c
+++ b/src/glm_layers.c
@@ -108,7 +108,7 @@ void check_layer_thickness(void)
                  DELDP = Lake[i].Height;
             else
                  DELDP = Lake[i].Height - Lake[i-1].Height;
-            if ((Lake[i].LayerVol < VMin) && (DELDP < DMin)) break;
+            if ((VMin - Lake[i].LayerVol) > 1e-4 && (DMin - DELDP) > 1e-4) break;
         }
 
         if (i > surfLayer) break;
@@ -190,7 +190,7 @@ void check_layer_thickness(void)
 
             if (i == surfLayer) VSUMCHK = TRUE;
 
-            if (Lake[i].LayerVol > VMax || DELDP > DMax) break;
+             if ((Lake[i].LayerVol-VMax) > 1e-4 || (DELDP - DMax) > 1e-4) break;
         }
 
         // return to calling program when all layers have been checked

--- a/src/glm_mixer.c
+++ b/src/glm_mixer.c
@@ -191,7 +191,7 @@ static int convective_overturn(int *_Epi_botmLayer, int *_Meta_topLayer,
             ZeroMom  = ZeroMom  + tRho;
             FirstMom = FirstMom + tRho * Lake[Epi_botmLayer].MeanHeight;
 
-            if (Dens_Epil < Lake[Epi_botmLayer-1].Density+1e-4) break;
+            if (Dens_Epil < Lake[Epi_botmLayer-1].Density+1e-7) break;
         } else {
             AED_REAL tRho = (Lake[botmLayer].Density - rho0) * Lake[botmLayer].Height;
             ZeroMom  = ZeroMom  + tRho;
@@ -570,12 +570,9 @@ static int shear_production(int Mixer_Count, int *_Epi_botmLayer, int *_Meta_top
     
     // return 0; //CAB DEBUG
     //# Momentum update
-    if (u0 < 1E-7){
-     u0 = zero;
-     }
-    if (Slope < 1E-7){ 
-    Slope = zero;
-    }
+    if (u0 < 1E-7) u0 = zero;
+    if (Slope < 1E-7) Slope = zero;
+    
     u_f = u0 + Slope * Time_end_shear * SecsPerHr;
 
     u_avgSQ = (u_f*u_f + u_f*u0 + u0*u0) / 3.0;

--- a/src/glm_mixer.c
+++ b/src/glm_mixer.c
@@ -94,6 +94,8 @@ AED_REAL u_f     = 0.;
 AED_REAL u0      = 0.;
 AED_REAL u_avg   = 0.;
 
+int Mixer_Count = 0;   //# Mixer model step counter
+
 //# Wind parameters
 static AED_REAL WindSpeedX;  //# Actual wind speed, accounting for wind factor or ice [m s-1]
 static AED_REAL U_star;      //# U*, wind induced surface water shear speed [m s-1]
@@ -189,7 +191,7 @@ static int convective_overturn(int *_Epi_botmLayer, int *_Meta_topLayer,
             ZeroMom  = ZeroMom  + tRho;
             FirstMom = FirstMom + tRho * Lake[Epi_botmLayer].MeanHeight;
 
-            if (Dens_Epil < Lake[Epi_botmLayer-1].Density+1e-6) break;
+            if (Dens_Epil < Lake[Epi_botmLayer-1].Density+1e-4) break;
         } else {
             AED_REAL tRho = (Lake[botmLayer].Density - rho0) * Lake[botmLayer].Height;
             ZeroMom  = ZeroMom  + tRho;
@@ -467,7 +469,7 @@ static int shear_production(int Mixer_Count, int *_Epi_botmLayer, int *_Meta_top
      * Dens_Epi is the epilimnion density                                     *
      *                                                                        *
      **************************************************************************/
-
+     
     //# Calculate Kraus-Turner depth (change in SML depth over dt)
     zsml_tilda = MAX( DepMX - Lake[Meta_topLayer].Height, zero );
 
@@ -543,8 +545,9 @@ static int shear_production(int Mixer_Count, int *_Epi_botmLayer, int *_Meta_top
     Slope = (accn-FO) + OldSlope;
     if (accn <= zero) Slope = zero;
     else if (fabs(Slope/accn) <= 1e-5) Slope = zero;
+    
     if (Slope < zero) Slope = zero;
-
+    
     /**************************************************************************
      * Check for momentum cutoff within current time step. Calculate time step*
      * for forcing, Time_end_shear, and reset parameters for next time step   *
@@ -555,18 +558,24 @@ static int shear_production(int Mixer_Count, int *_Epi_botmLayer, int *_Meta_top
          //# Here if cutoff within current time step
          Time_end_shear = Time_count_end_shear - Time_count_sim + noSecs/SecsPerHr;
          OldSlope = accn - (FSUM / (Mixer_Count));
+         
          if (OldSlope < zero) OldSlope = zero;
     } else {
+
          //# Still shearing ...
          Time_end_shear = noSecs/SecsPerHr;
          OldSlope = Slope;
     }
     FO = accn;
-
+    
     // return 0; //CAB DEBUG
     //# Momentum update
-    if (u0 < 1E-7) u0 = zero;
-    if (Slope < 1E-7) Slope = zero;
+    if (u0 < 1E-7){
+     u0 = zero;
+     }
+    if (Slope < 1E-7){ 
+    Slope = zero;
+    }
     u_f = u0 + Slope * Time_end_shear * SecsPerHr;
 
     u_avgSQ = (u_f*u_f + u_f*u0 + u0*u0) / 3.0;
@@ -636,6 +645,7 @@ static int shear_production(int Mixer_Count, int *_Epi_botmLayer, int *_Meta_top
         Vol_Epi = Vol_Epi + Lake[Meta_topLayer+1].LayerVol;
         Epi_Thick = (Vol_Epi / (Lake[Meta_topLayer].LayerArea + Lake[surfLayer].LayerArea)) * 2.0;
         u_f = u_f * PrevThick / Epi_Thick;
+        
         u_avg = sqrt((u0_old*u0_old + u0_old*u_f + u_f*u_f)/3.0);
 
         del_u = u_avg - u_eff;
@@ -715,13 +725,14 @@ static AED_REAL kelvin_helmholtz(int *Meta_topLayer, int *Epi_botmLayer, AED_REA
     if (surfLayer <= botmLayer || bilshear > 10.0) return Dens;
 
     Delta_Mix = (coef_mix_KH*u_avg*u_avg)/(gPrimeTwoLayer*2.0*cosh(bilshear));
-
+    
     //# Limit the thickness of the mixing layer to less than either the hypolimnion or epilimnion
     HMIN = MIN(Epi_dz, Thermocline_Height);
     if (Delta_Mix > HMIN) Delta_Mix = HMIN;
     eTop = Thermocline_Height + Delta_Mix;
     eBot = Thermocline_Height - Delta_Mix;
     top = FALSE;
+
     if (eTop > Lake[surfLayer-1].Height) eTop = Lake[surfLayer-1].Height;
     if ((eTop-Thermocline_Height) < eps6/2.0) return Dens;
     if (eBot < Lake[botmLayer].Height) eBot = Lake[botmLayer].Height;
@@ -763,7 +774,7 @@ static AED_REAL kelvin_helmholtz(int *Meta_topLayer, int *Epi_botmLayer, AED_REA
             Lake[Meta_botmLayer].Height = eBot;
         }
     }
-
+    
     //# Here after position (ebot) of bottom of shear zone has been
     //# determined and extra layer added, if necessary
     T = fabs(eTop-eBot);
@@ -830,6 +841,7 @@ static AED_REAL kelvin_helmholtz(int *Meta_topLayer, int *Epi_botmLayer, AED_REA
             }
         }
     }
+    
 
     //# Here after bottom half of shear zone has at least three layers,
     //# divide top half of shear zone into nl layers
@@ -971,7 +983,7 @@ static int mixed_layer_deepening(AED_REAL *WQ_VarsM, int Mixer_Count,
      **************************************************************************/
     if (ice) WindSpeedX = 1e-5;
     else     WindSpeedX = MetData.WindSpeed;
-
+    
     /**************************************************************************
      * Calculate shear velocity U*, U*^2 and U*^3                             *
      **************************************************************************/
@@ -1073,7 +1085,6 @@ void do_mixing()
     int Meta_topLayer;            //# Index for top layer of hypolimnion
     AED_REAL Dens_Epil;           //# Mean epilimnion density [kg/m3]
     AED_REAL Vol_Hypl;            //# Volume of hypolimnion [m^3]
-    static int Mixer_Count = 0;   //# Mixer model step counter
     int res = -1;
 
 /*----------------------------------------------------------------------------*/
@@ -1085,6 +1096,7 @@ void do_mixing()
 
     switch ( (res = mixed_layer_deepening(WQ_VarsM, Mixer_Count, &Meta_topLayer, &Dens_Epil)) ) {
         case DEEPENED_BOT:
+    
             //# Here if deepened to bottom
             OldSlope = zero; //# Old slope = zero as fully mixed
             Energy_AvailableMix = zero;   //# Total available energy to mix reset to zero as lake fully mixed
@@ -1100,6 +1112,7 @@ void do_mixing()
             /***** fall through ******/
 
          case MOMENTUM_CUT:
+
             //# Here if momentum cutoff
             Mixer_Count = 0;  //# Reset mixing model step count (note: not reset if case IS_MIXED)
             FSUM = zero;
@@ -1117,6 +1130,7 @@ void do_mixing()
             /***** fall through ******/
 
         case IS_MIXED:
+
             //# Meta_topLayer+1 becomes the surface layer == mixed epilimnion layers
             Lake[Meta_topLayer+1].Height = Lake[surfLayer].Height;
             Lake[Meta_topLayer+1].Temp = MeanTemp;

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -122,7 +122,7 @@ void run_model()
 
     begn = time(NULL);
     if (quiet < 10) printf("\n     Wall clock start time :  %s", ctime_r(&begn, buf));
-
+    
     if (non_avg)
         do_model_non_avg(jstart, nsave);
     else
@@ -497,7 +497,7 @@ void do_model_non_avg(int jstart, int nsave)
         //# Now enter into sub-daily calculations            ------>
 
         stepnum = do_subdaily_loop(stepnum, jday, stoptime, nsave, SWold, SWnew);
-
+        
         //# End of forcing-mixing-diffusion loop             ------>
 
 

--- a/src/glm_ncdf.c
+++ b/src/glm_ncdf.c
@@ -61,7 +61,7 @@ static size_t start_r[1],edges_r[1];
 static int lon_id,lat_id,z_id,H_id,V_id,TV_id,Taub_id,NS_id,time_id;
 static int SL_id,HICE_id,HSNOW_id,HWICE_id, AvgSurfTemp_id;
 static int precip_id,evap_id,rho_id,rad_id,extc_id,i0_id,wnd_id;
-static int temp_id, salt_id, umean_id, uorb_id, restart_id;
+static int temp_id, salt_id, umean_id, uorb_id, restart_id, Mixer_Count_id;
 
 //# from lake.csv
 static int SA_id, VSnow_id,VBIce_id,VWIce_id, TotInVol_id, TotOutVol_id;
@@ -125,7 +125,8 @@ int init_glm_ncdf(const char *fn, const char *title, AED_REAL lat,
     check_nc_error(nc_def_var(ncid, "white_ice_thickness", NC_REALTYPE, 1, dims, &HWICE_id));
     check_nc_error(nc_def_var(ncid, "surface_layer",       NC_INT,      1, dims, &SL_id));
     check_nc_error(nc_def_var(ncid, "avg_surf_temp",       NC_REALTYPE, 1, dims, &AvgSurfTemp_id));
-
+    check_nc_error(nc_def_var(ncid, "Mixer_Count",    NC_INT,      1, dims, &Mixer_Count_id));
+    
     dims[0] = restart_dim;
     check_nc_error(nc_def_var(ncid, "restart_variables", NC_REALTYPE, 1, dims, &restart_id));
 
@@ -348,7 +349,7 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
 
     //# Restart variables
     /*------------------------------------------------------------------------*/
-    restart_variables   = malloc(17*sizeof(AED_REAL));
+    restart_variables   = malloc(18*sizeof(AED_REAL));
     restart_variables[0] = DepMX;
     restart_variables[1] = PrevThick;
     restart_variables[2] = gPrimeTwoLayer;
@@ -366,11 +367,15 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
     restart_variables[14] = u_f;
     restart_variables[15] = u0;
     restart_variables[16] = u_avg;
+    restart_variables[17] = Mixer_Count;
+    
 
     start_r[0] = 0; edges_r[0] = restart_len;
 
     iret = nc_put_vara(ncid,  restart_id, start_r, edges_r, restart_variables);
     if ( iret != NC_NOERR ) check_nc_error_x(iret, ncid, restart_id);
+    
+    store_nc_integer(ncid, Mixer_Count_id, T_SHAPE, Mixer_Count);
 
     //# Time varying profile data : z,t
     /*------------------------------------------------------------------------*/

--- a/src/glm_ncdf.c
+++ b/src/glm_ncdf.c
@@ -349,7 +349,7 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
 
     //# Restart variables
     /*------------------------------------------------------------------------*/
-    restart_variables   = malloc(18*sizeof(AED_REAL));
+    restart_variables   = malloc(17*sizeof(AED_REAL));
     restart_variables[0] = DepMX;
     restart_variables[1] = PrevThick;
     restart_variables[2] = gPrimeTwoLayer;
@@ -367,7 +367,6 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
     restart_variables[14] = u_f;
     restart_variables[15] = u0;
     restart_variables[16] = u_avg;
-    restart_variables[17] = Mixer_Count;
     
 
     start_r[0] = 0; edges_r[0] = restart_len;


### PR DESCRIPTION
I was able to produce a perfect run over a 6 month simulation period where I ran the code all the way through using a single GLM-AED run and again running one day at a time (output.nc -> glm3.nml). The updates in this PR were necessary along with fix in https://github.com/AquaticEcoDynamics/GLM/issues/47#issue-2328509365 is needed.  I hacked the Epilson fix by setting deep_mixing = 1 and initializing epilson in glm_init using 
```       
for (i = 0; i < NumLayers; i++)
          Lake[i].Epsilon = coef_mix_hyp;
```

I didn't include this hack in the PR.  

Summary
- The PR adds numerical tolerance when comparing the volumes of two layers
- The PR fixes a bug when initializing using `the_heights`.  

The restart test used GLM-AED with static N:P rations for phytos and with submerged inflows.  