### PR TITLE
Moving inflows/outflows to after subdaily but adding output write into daily loop

### DIFF
--- a/src/glm_flow.c
+++ b/src/glm_flow.c
@@ -489,13 +489,17 @@ AED_REAL do_overflow(int jday)
     AED_REAL overflow = 0.;
 
     // Too much water for the entire lake domain, remove this first
-    if (VolSum > MaxVol){
+    
+    
+    if ((VolSum - MaxVol) > 1e-4){
+    //if (VolSum > MaxVol){
       do_single_outflow((CrestHeight+(MaxHeight-CrestHeight)*0.9), (VolSum - MaxVol), NULL);
       overflow = VolSum - Lake[surfLayer].Vol1;
     }
     VolSum = Lake[surfLayer].Vol1;
     // Water above the crest, which will overflow based on a weir equation
-    if (VolSum > VolAtCrest){
+    if ((VolSum - VolAtCrest) > 1e-4){
+    //if (VolSum > VolAtCrest){
         AED_REAL ovfl_Q, ovfl_dz;
 
         ovfl_dz = MAX( Lake[surfLayer].Height - CrestHeight, zero );

--- a/src/glm_flow.c
+++ b/src/glm_flow.c
@@ -491,15 +491,13 @@ AED_REAL do_overflow(int jday)
     // Too much water for the entire lake domain, remove this first
     
     
-    if ((VolSum - MaxVol) > 1e-4){
-    //if (VolSum > MaxVol){
+    if (VolSum > MaxVol){
       do_single_outflow((CrestHeight+(MaxHeight-CrestHeight)*0.9), (VolSum - MaxVol), NULL);
       overflow = VolSum - Lake[surfLayer].Vol1;
     }
     VolSum = Lake[surfLayer].Vol1;
     // Water above the crest, which will overflow based on a weir equation
-    if ((VolSum - VolAtCrest) > 1e-4){
-    //if (VolSum > VolAtCrest){
+    if (VolSum > VolAtCrest){
         AED_REAL ovfl_Q, ovfl_dz;
 
         ovfl_dz = MAX( Lake[surfLayer].Height - CrestHeight, zero );

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1373,9 +1373,6 @@ void create_lake(int namlst)
     LenAtCrest = bsn_len;
     WidAtCrest = bsn_wid;
     
-    
-    fprintf(stdout, "crest_elev %f Base %f CrestHeight%f max_elev %f MaxHeight %f\n", crest_elev, Base, CrestHeight, max_elev, MaxHeight);
-
     alpha_b = calloc(MaxLayers, sizeof(AED_REAL));
     beta_b = calloc(MaxLayers, sizeof(AED_REAL));
 
@@ -1682,12 +1679,6 @@ void initialise_lake(int namlst)
         ice = TRUE;
     }
     
-    //if (deep_mixing == 1) {      //constant diffusivity over whole water column
-        for (i = 0; i < NumLayers; i++)
-          Lake[i].Epsilon = coef_mix_hyp;
-    //}
-    
-
     AvgSurfTemp = avg_surf_temp;
 
     if (restart_variables != NULL) {

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1365,11 +1365,16 @@ void create_lake(int namlst)
     Nmorph = ( ( H[bsn_vals-1] * MphInc ) + 1.0 / 1000.0 ) + 10;
 
     allocate_storage();
+    
+
 
     CrestHeight = crest_elev - Base;
     MaxHeight = max_elev - Base;
     LenAtCrest = bsn_len;
     WidAtCrest = bsn_wid;
+    
+    
+    fprintf(stdout, "crest_elev %f Base %f CrestHeight%f max_elev %f MaxHeight %f\n", crest_elev, Base, CrestHeight, max_elev, MaxHeight);
 
     alpha_b = calloc(MaxLayers, sizeof(AED_REAL));
     beta_b = calloc(MaxLayers, sizeof(AED_REAL));
@@ -1677,10 +1682,10 @@ void initialise_lake(int namlst)
         ice = TRUE;
     }
     
-    if (deep_mixing == 1) {      //constant diffusivity over whole water column
+    //if (deep_mixing == 1) {      //constant diffusivity over whole water column
         for (i = 0; i < NumLayers; i++)
           Lake[i].Epsilon = coef_mix_hyp;
-    }
+    //}
     
 
     AvgSurfTemp = avg_surf_temp;

--- a/src/glm_layers.c
+++ b/src/glm_layers.c
@@ -99,6 +99,13 @@ void check_layer_thickness(void)
 /*----------------------------------------------------------------------------*/
     dbgprt(" CHKLAY 01 lake[44].depth = %20.15f\n", Lake[44].Height);
 
+
+
+ //fprintf(stdout, "check_layer_thickness #1\n");
+ //   for (i = botmLayer; i <= surfLayer; i++) {
+  //     fprintf(stdout, "layer %d %f %f %f\n", i, Lake[i].Temp, Lake[i].LayerVol, Lake[i].LayerArea);
+ //   }
+       
     //# Check against vmin
     KLAST=botmLayer;
     // while (1) { //
@@ -128,7 +135,9 @@ void check_layer_thickness(void)
         }
 
         j = i;
-        if (Vup > Vdown) j = i-1;
+        
+       if((Vup - Vdown) > 1e-4) j = i-1;
+    //if (Vup > Vdown) j = i-1;
 
         Lake[j].Salinity = combine(Lake[j].Salinity,   Lake[j].LayerVol,   Lake[j].Density,
                                    Lake[j+1].Salinity, Lake[j+1].LayerVol, Lake[j+1].Density);
@@ -167,6 +176,12 @@ void check_layer_thickness(void)
         }
         NumLayers--;
     }
+    
+ //fprintf(stdout, "check_layer_thickness #2\n");
+ //   for (i = botmLayer; i <= surfLayer; i++) {
+  //     fprintf(stdout, "layer %d %f %f %f\n", i, Lake[i].Temp, Lake[i].LayerVol, Lake[i].LayerArea);
+  //  }
+       
 
     // here when all layers have been checked for VMin, DMin
     if (surfLayer != botmLayer) {
@@ -174,6 +189,8 @@ void check_layer_thickness(void)
             Lake[i].MeanHeight=(Lake[i].Height+Lake[i-1].Height)/ 2.0;
     }
     Lake[botmLayer].MeanHeight = Lake[botmLayer].Height/ 2.0;
+    
+    
 
     // check layers for VMax
     //sgs Flag to prevent top layer splitting more than once
@@ -190,7 +207,11 @@ void check_layer_thickness(void)
 
             if (i == surfLayer) VSUMCHK = TRUE;
 
-             if ((Lake[i].LayerVol-VMax) > 1e-7 || (DELDP - DMax) > 1e-7) break;
+             if ((Lake[i].LayerVol-VMax) > 1e-7 || (DELDP - DMax) > 1e-7){
+
+             break;
+             
+             } 
         }
 
         // return to calling program when all layers have been checked
@@ -201,7 +222,8 @@ void check_layer_thickness(void)
         while (1) {
             V = Lake[i].LayerVol/M;
             D = DELDP/M;
-            if (V <= VMax && D <= DMax) break;
+            if((VMax - V) > 1e-7 && (DMax - D) > 1e-7) break;
+            //if (V <= VMax && D <= DMax) break;
             if (Lake[surfLayer].Height<0.3) break;
             M++;
 
@@ -214,7 +236,7 @@ void check_layer_thickness(void)
                 exit(1);
             }
         }
-
+        
         // renumber layers above split. iadd is the number of added layers
         // j is the new layer number, jold is the old layer number
         // include water quality
@@ -237,7 +259,7 @@ void check_layer_thickness(void)
                 Lake[j].Epsilon = Lake[jold].Epsilon;
             }
         }
-
+        
         // process the added layers, include water quality
         for (k=i; k <= i+iadd; k++) {
             Lake[k].LayerVol = V;
@@ -255,12 +277,16 @@ void check_layer_thickness(void)
 
             Lake[k].Epsilon = Lake[i].Epsilon;
         }
+        
         NumLayers += iadd;
 
         // get new depths for layers i thru surfLayer
         resize_internals(2,i);
 
     }
+    
+ 
+
 }
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 

--- a/src/glm_layers.c
+++ b/src/glm_layers.c
@@ -100,12 +100,6 @@ void check_layer_thickness(void)
     dbgprt(" CHKLAY 01 lake[44].depth = %20.15f\n", Lake[44].Height);
 
 
-
- //fprintf(stdout, "check_layer_thickness #1\n");
- //   for (i = botmLayer; i <= surfLayer; i++) {
-  //     fprintf(stdout, "layer %d %f %f %f\n", i, Lake[i].Temp, Lake[i].LayerVol, Lake[i].LayerArea);
- //   }
-       
     //# Check against vmin
     KLAST=botmLayer;
     // while (1) { //
@@ -136,8 +130,7 @@ void check_layer_thickness(void)
 
         j = i;
         
-       if((Vup - Vdown) > 1e-4) j = i-1;
-    //if (Vup > Vdown) j = i-1;
+       if (Vup > Vdown) j = i-1;
 
         Lake[j].Salinity = combine(Lake[j].Salinity,   Lake[j].LayerVol,   Lake[j].Density,
                                    Lake[j+1].Salinity, Lake[j+1].LayerVol, Lake[j+1].Density);
@@ -177,12 +170,6 @@ void check_layer_thickness(void)
         NumLayers--;
     }
     
- //fprintf(stdout, "check_layer_thickness #2\n");
- //   for (i = botmLayer; i <= surfLayer; i++) {
-  //     fprintf(stdout, "layer %d %f %f %f\n", i, Lake[i].Temp, Lake[i].LayerVol, Lake[i].LayerArea);
-  //  }
-       
-
     // here when all layers have been checked for VMin, DMin
     if (surfLayer != botmLayer) {
         for (i = botmLayer+1; i <= surfLayer; i++)

--- a/src/glm_mixer.c
+++ b/src/glm_mixer.c
@@ -191,7 +191,7 @@ static int convective_overturn(int *_Epi_botmLayer, int *_Meta_topLayer,
             ZeroMom  = ZeroMom  + tRho;
             FirstMom = FirstMom + tRho * Lake[Epi_botmLayer].MeanHeight;
 
-            if (Dens_Epil < Lake[Epi_botmLayer-1].Density+1e-4) break;
+            if (Dens_Epil < Lake[Epi_botmLayer-1].Density+1e-7) break;
         } else {
             AED_REAL tRho = (Lake[botmLayer].Density - rho0) * Lake[botmLayer].Height;
             ZeroMom  = ZeroMom  + tRho;

--- a/src/glm_mixer.c
+++ b/src/glm_mixer.c
@@ -191,7 +191,7 @@ static int convective_overturn(int *_Epi_botmLayer, int *_Meta_topLayer,
             ZeroMom  = ZeroMom  + tRho;
             FirstMom = FirstMom + tRho * Lake[Epi_botmLayer].MeanHeight;
 
-            if (Dens_Epil < Lake[Epi_botmLayer-1].Density+1e-7) break;
+            if (Dens_Epil < Lake[Epi_botmLayer-1].Density+1e-4) break;
         } else {
             AED_REAL tRho = (Lake[botmLayer].Density - rho0) * Lake[botmLayer].Height;
             ZeroMom  = ZeroMom  + tRho;

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -107,6 +107,8 @@ int do_subdaily_loop(int stepnum, int jday, int stoptime, int nsave, AED_REAL SW
 int startTOD = 0;
 int stopTOD = 0;
 int nDates = 1;
+int write_step;
+int last_step;
 
 
 /******************************************************************************
@@ -360,7 +362,36 @@ void do_model(int jstart, int nsave)
 
         //# End of forcing-mixing-diffusion loop             ------>
 
+        //# Read & set today's outflow properties
+        SurfData.dailyInflow = do_inflows(); //# Do inflow for all streams
+
+        //# Extract withdrawal from all offtakes
+        SurfData.dailyOutflow = do_outflows(jday);
+
+        //# Take care of any overflow
+        SurfData.dailyOverflow = do_overflow(jday);
+        
+        //# Enforce layer limits
         check_layer_thickness();
+        
+        // # Write output on last time step within a day 
+        // # after including the inflow and outflows.
+        // # Output is not written on the last time step in a daily in the subdaily loop
+        if ( stepnum == write_step){
+                    printf("writing daily at stepnum %d jday %d \n",stepnum, jday);
+       
+#if PLOTS
+            today = jday;
+#endif
+            write_output(jday, SecsPerDay, nsave, stepnum);
+            write_step += nsave;
+            if ( write_step > last_step ) write_step = last_step;
+#if PLOTS
+            plotstep++;
+            today = -1;
+#endif
+        
+        }
 
         /*--------------------------------------------------------------------*
          * End of daily calculations, Prepare for next day and return.        *
@@ -471,21 +502,7 @@ void do_model_non_avg(int jstart, int nsave)
 
         read_daily_withdraw_temp(jday, &WithdrTempNew);
         WithdrawalTemp = WithdrTempNew;
-
-        //# Insert inflows for all streams
-        SurfData.dailyInflow = do_inflows();
-
-        if(Lake[surfLayer].Vol1>zero) {
-          //# Extract withdrawal from all offtakes
-          SurfData.dailyOutflow = do_outflows(jday);
-
-          //# Take care of any overflow
-          SurfData.dailyOverflow = do_overflow(jday);
-        }
-
-        //# Enforce layer limits
-        check_layer_thickness();
-
+        
         //# Read & set today's Kw (if it is being read in)
         read_daily_kw(jday, &DailyKw);
         for (i = 0; i < MaxLayers; i++) Lake[i].ExtcCoefSW = DailyKw;
@@ -495,12 +512,44 @@ void do_model_non_avg(int jstart, int nsave)
         SWnew = MetData.ShortWave;
 
         //# Now enter into sub-daily calculations            ------>
-
+                
         stepnum = do_subdaily_loop(stepnum, jday, stoptime, nsave, SWold, SWnew);
         
         //# End of forcing-mixing-diffusion loop             ------>
+        
+         //# Insert inflows for all streams
+        SurfData.dailyInflow = do_inflows();
+        
+        if(Lake[surfLayer].Vol1>zero) {
+          //# Extract withdrawal from all offtakes
+          SurfData.dailyOutflow = do_outflows(jday);
 
-
+          //# Take care of any overflow
+          SurfData.dailyOverflow = do_overflow(jday);
+        }
+        
+        //# Enforce layer limits
+        check_layer_thickness();
+        
+        // # Write output on last time step within a day 
+        // # after including the inflow and outflows.
+        // # Output is not written on the last time step in a daily in the subdaily loop
+        if ( stepnum == write_step){
+                    printf("writing daily at stepnum %d jday %d \n",stepnum, jday);
+       
+#if PLOTS
+            today = jday;
+#endif
+            write_output(jday, SecsPerDay, nsave, stepnum);
+            write_step += nsave;
+            if ( write_step > last_step ) write_step = last_step;
+#if PLOTS
+            plotstep++;
+            today = -1;
+#endif
+        
+        }
+                
         /***********************************************************************
          * End of daily calculations, Prepare for next day and return.         *
          **********************************************************************/
@@ -599,18 +648,6 @@ void do_model_coupled(int step_start, int step_end,
     //  read_daily_withdraw_temp(jday, &WithdrTempNew);
     //  WithdrawalTemp = WithdrTempNew;
 
-        SurfData.dailyInflow = do_inflows(); //# Do inflow for all streams
-
-        if (Lake[surfLayer].Vol1 > zero) {
-            //# Do withdrawal for all offtakes
-            SurfData.dailyOutflow = do_outflows(jday);
-
-            //# Take care of any overflow
-            SurfData.dailyOverflow = do_overflow(jday);
-        }
-
-        check_layer_thickness();
-
         read_daily_kw(jday, &DailyKw);
         for (i = 0; i < MaxLayers; i++) Lake[i].ExtcCoefSW = DailyKw;
 
@@ -624,7 +661,40 @@ void do_model_coupled(int step_start, int step_end,
 
         //# End of forcing-mixing-diffusion loop
 
+         //# Insert inflows for all streams
+        SurfData.dailyInflow = do_inflows();
+        
+        if(Lake[surfLayer].Vol1>zero) {
+          //# Extract withdrawal from all offtakes
+          SurfData.dailyOutflow = do_outflows(jday);
+
+          //# Take care of any overflow
+          SurfData.dailyOverflow = do_overflow(jday);
+        }
+        
+        //# Enforce layer limits
         check_layer_thickness();
+        
+        // # Write output on last time step within a day 
+        // # after including the inflow and outflows.
+        // # Output is not written on the last time step in a daily in the subdaily loop
+        if ( stepnum == write_step){
+                    printf("writing daily at stepnum %d jday %d \n",stepnum, jday);
+       
+#if PLOTS
+            today = jday;
+#endif
+            write_output(jday, SecsPerDay, nsave, stepnum);
+            write_step += nsave;
+            if ( write_step > last_step ) write_step = last_step;
+#if PLOTS
+            plotstep++;
+            today = -1;
+#endif
+        
+        }
+                
+        
 
         /**********************************************************************
          * End of daily calculations, Prepare for next day and return.        *
@@ -683,7 +753,7 @@ int do_subdaily_loop(int stepnum, int jday, int stoptime, int nsave, AED_REAL SW
 {
     int iclock;  //# The seconds counter during a day
     AED_REAL Light_Surface; //# Light at the surface of the lake after do_surface
-    int write_step, last_step;
+    //int write_step, last_step;
     AED_REAL part_day_per_step;
 
     yearday = day_of_year(jday);
@@ -717,27 +787,36 @@ int do_subdaily_loop(int stepnum, int jday, int stoptime, int nsave, AED_REAL SW
 
         stepnum++;
         _dbg_time(jday, iclock);
+        
+        
+        fprintf(stdout, "iclock %d\n", iclock);
+
 
 //fprintf(stderr, "Lake[surfLayer].Height = %f\n", Lake[surfLayer].Height);
+
+
+        //fprintf(stdout, "#1 %f %f %f\n", Lake[5].Temp, Lake[5].LayerVol, Lake[5].LayerArea);
+
 
         //# Thermal transfers are done by do_surface_thermodynamics
         do_surface_thermodynamics(jday, iclock, lw_ind, Latitude, SWold, SWnew);
+        
 
-//fprintf(stderr, "Lake[surfLayer].Height = %f\n", Lake[surfLayer].Height);
-//exit(0);
         //# Save surface light to use at end of sub-daily time loop
         Light_Surface = Lake[surfLayer].Light/0.45;
 
         //# Mixing is done by do_mixing
         if ( surface_mixing > 0 )
             do_mixing();
-
+            
 //      calc_mass_temp("After do_mixing");
 
         //# Mix out instabilities, combine/split  layers
         check_layer_thickness();
+        
         fix_radiation(Light_Surface);
-
+        
+                
         if ( surface_mixing > -1 ){
              check_layer_stability();
              fix_radiation(Light_Surface);
@@ -753,29 +832,31 @@ int do_subdaily_loop(int stepnum, int jday, int stoptime, int nsave, AED_REAL SW
             //# Do deep mixing integrations
             //# If reservoir is mixed (NumLayers<3) then skip deep mixing
             if (NumLayers > 3) do_deep_mixing();
-
+            
             //# Check mixed layers for volume
             check_layer_thickness();
+            
         }
         fix_radiation(Light_Surface);
-
+        
         //# Calculate the percent benthic area where the light level is greater
         //# than the minimum level required for production
         Benthic_Light_pcArea += calc_benthic_light();
-
+        
         calc_layer_stress(MetData.WindSpeed,
                       sqrt( (Lake[surfLayer].LayerArea)/Pi ) * 2 );
-
+                      
         /**********************************************************************
          *## Start Water Quality calls                                        *
          **********************************************************************/
         if (wq_calc) wq_do_glm(&NumLayers, &ice);
-
-        if ( stepnum == write_step ) {
+        
+        if ( stepnum == write_step & (iclock +  noSecs) != SecsPerDay) {
+        
 #if PLOTS
             today = jday;
 #endif
-//          printf("writing at stepnum %d\n",stepnum);
+            printf("writing subdaily at stepnum %d jday %d iclock %d \n",stepnum, jday, iclock);
             write_output(jday, iclock, nsave, stepnum);
             write_step += nsave;
             if ( write_step > last_step ) write_step = last_step;

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -378,7 +378,6 @@ void do_model(int jstart, int nsave)
         // # after including the inflow and outflows.
         // # Output is not written on the last time step in a daily in the subdaily loop
         if ( stepnum == write_step){
-                    printf("writing daily at stepnum %d jday %d \n",stepnum, jday);
        
 #if PLOTS
             today = jday;
@@ -535,7 +534,6 @@ void do_model_non_avg(int jstart, int nsave)
         // # after including the inflow and outflows.
         // # Output is not written on the last time step in a daily in the subdaily loop
         if ( stepnum == write_step){
-                    printf("writing daily at stepnum %d jday %d \n",stepnum, jday);
        
 #if PLOTS
             today = jday;
@@ -679,7 +677,6 @@ void do_model_coupled(int step_start, int step_end,
         // # after including the inflow and outflows.
         // # Output is not written on the last time step in a daily in the subdaily loop
         if ( stepnum == write_step){
-                    printf("writing daily at stepnum %d jday %d \n",stepnum, jday);
        
 #if PLOTS
             today = jday;
@@ -753,7 +750,6 @@ int do_subdaily_loop(int stepnum, int jday, int stoptime, int nsave, AED_REAL SW
 {
     int iclock;  //# The seconds counter during a day
     AED_REAL Light_Surface; //# Light at the surface of the lake after do_surface
-    //int write_step, last_step;
     AED_REAL part_day_per_step;
 
     yearday = day_of_year(jday);
@@ -788,16 +784,6 @@ int do_subdaily_loop(int stepnum, int jday, int stoptime, int nsave, AED_REAL SW
         stepnum++;
         _dbg_time(jday, iclock);
         
-        
-        fprintf(stdout, "iclock %d\n", iclock);
-
-
-//fprintf(stderr, "Lake[surfLayer].Height = %f\n", Lake[surfLayer].Height);
-
-
-        //fprintf(stdout, "#1 %f %f %f\n", Lake[5].Temp, Lake[5].LayerVol, Lake[5].LayerArea);
-
-
         //# Thermal transfers are done by do_surface_thermodynamics
         do_surface_thermodynamics(jday, iclock, lw_ind, Latitude, SWold, SWnew);
         
@@ -851,12 +837,15 @@ int do_subdaily_loop(int stepnum, int jday, int stoptime, int nsave, AED_REAL SW
          **********************************************************************/
         if (wq_calc) wq_do_glm(&NumLayers, &ice);
         
+        //# If an output write is requested for the last time step of the day
+        //# then do not output in the subdaily.  Output writing is moved to the
+        //# daily loop so it occurs after the inflow and output calculations.
+        
         if ( stepnum == write_step & (iclock +  noSecs) != SecsPerDay) {
         
 #if PLOTS
             today = jday;
 #endif
-            printf("writing subdaily at stepnum %d jday %d iclock %d \n",stepnum, jday, iclock);
             write_output(jday, iclock, nsave, stepnum);
             write_step += nsave;
             if ( write_step > last_step ) write_step = last_step;

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -286,6 +286,7 @@ void do_model(int jstart, int nsave)
 
         //# If it is the last day, adjust the stop time for the day if necessary
         if (ntot == nDates) stoptime = stopTOD;
+        if(stoptime == 0) break;
 
         //# Initialise daily values for volume and heat balance output
         SurfData.dailyRain = 0.; SurfData.dailyEvap = 0.;
@@ -463,6 +464,7 @@ void do_model_non_avg(int jstart, int nsave)
 
         //# If it is the last day, adjust the stop time for the day if necessary
         if(ntot == nDates) stoptime = stopTOD;
+        if(stoptime == 0) break;
 
         //# Initialise daily values for volume & heat balance reporting (lake.csv)
         SurfData.dailyRain    = 0.; SurfData.dailyEvap     = 0.;
@@ -613,6 +615,7 @@ void do_model_coupled(int step_start, int step_end,
 
         //# If it is the last day, adjust the stop time for the day if necessary
         if(ntot == nDates) stoptime = stopTOD;
+        if(stoptime == 0) break;
 
         //# Initialise daily values for volume and heat balance output
         SurfData.dailyRain = 0.; SurfData.dailyEvap = 0.;

--- a/src/glm_surface.c
+++ b/src/glm_surface.c
@@ -236,6 +236,9 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
     ***********************************************************************/
 
     AED_REAL catch_runoff = zero;
+    
+    
+    //fprintf(stdout, "###1 %f\n", Lake[5].Temp);
 
     if ( catchrain && MetData.Rain>rain_threshold ) {
 
@@ -277,6 +280,8 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
 
         SurfData.dailyRunoff += catch_runoff;
     }
+    
+     //fprintf(stdout, "###2 %f\n", Lake[5].Temp);
 
     /**********************************************************************
     * Now get ready for surface heating
@@ -318,6 +323,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
     if (ice) WindSp = 0.0001;
     else     WindSp = MetData.WindSpeed;
 
+ //fprintf(stdout, "###3 %f\n", Lake[5].Temp);
 
     /**********************************************************************
      * ATMOSPHERIC CONDITIONS
@@ -331,7 +337,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
     // update air pressure at altitude
 //MetData.AirPres = atm_pressure_sl;
     p_atm = ((100.*MetData.AirPres) * pow((1 - 2.25577e-5*altitude),5.25588))/100.; //> hPa
-//fprintf(stderr, "MetData.AirPres %f p_atm %f altitude %f\n", MetData.AirPres, p_atm, altitude);
+////fprintf(stderr, "MetData.AirPres %f p_atm %f altitude %f\n", MetData.AirPres, p_atm, altitude);
     // gte the saturation vapour pressure at the water surface
     SatVap_surface = saturated_vapour(Lake[surfLayer].Temp); //> hPa
     // calculate gas constant for moist air
@@ -449,6 +455,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
     SurfData.dailyQsw += Lake[surfLayer].LayerArea * Q_shortwave * noSecs;
 
 
+ //fprintf(stdout, "###4 %f\n", Lake[5].Temp);
     // ---- MH TEST SOLPOND IN PROGRESS ---- //
     if (light_mode == 2){
 
@@ -486,6 +493,8 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
      * Assess surface mass fluxes of snow and rain on the ice
      * and check ice buoyancy for crackign and white ice formation
      *********************************************************************/
+     
+      //fprintf(stdout, "###5 %f\n", Lake[5].Temp);
     if (iclock == 0 && ice) {
         AED_REAL BuoyantPotential;
 
@@ -643,7 +652,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
         SUMSI  = SUMSI  + 0.0   + MetData.RainConcSi  * MetData.Rain ;
 
     }  // end iclock == 0 && ice
-
+ //fprintf(stdout, "###6 %f\n", Lake[5].Temp);
 
     /**********************************************************************
      * NON-PENETRATIVE HEAT FLUXES
@@ -834,6 +843,8 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
                 break;  // start melting
             }
         } // end while
+        
+         //fprintf(stdout, "###7 %f\n", Lake[5].Temp);
 
         //# Reset
         T01_NEW =  50.0;
@@ -941,6 +952,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
        SurfData.dailyQlw += Q_longwave * Lake[surfLayer].LayerArea * noSecs;
     }
 
+ //fprintf(stdout, "###8 %f\n", Lake[5].Temp);
     /***************************************************************************
      * APPLY HEATING TO WATER LAYERS
      * Now look at the ice or water interface
@@ -995,6 +1007,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
         Lake[onshoreLayer].Temp += dTemp;
     }
 
+ //fprintf(stdout, "###9 %f\n", Lake[5].Temp);
       /**************************************************************************
      * Check if the ice melted in code above
      *************************************************************************/
@@ -1094,6 +1107,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
         recalc_surface_salt();
     }
 
+ //fprintf(stdout, "###10 %f\n", Lake[5].Temp);
     /**************************************************************************
      * SEDIMENT HEATING
      * Sediment "heating" factor now applied to any layer based on which zone
@@ -1157,6 +1171,11 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
                }
             } else if ( sed_heat_model == 1 ){
               for (i = botmLayer+1; i <= surfLayer; i++) {
+              
+              
+                                if(i == 5){
+                    //fprintf(stdout, "Lake[i].Temp %f soil_heat_flux, %f Lake[i].LayerArea, %f Lake[i-1].LayerArea, %f Lake[i].Density, %f Lake[i].LayerVol %f\n",  Lake[i].Temp, soil_heat_flux, Lake[i].LayerArea,Lake[i-1].LayerArea, Lake[i].Density, Lake[i].LayerVol);
+                  }
                 TYEAR = sed_temp_mean[layer_zone[i]]
                         + sed_temp_amplitude[layer_zone[i]]
                         * cos(((kDays-sed_temp_peak_doy[layer_zone[i]])*2.*Pi)/365.);
@@ -1178,6 +1197,7 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
 //                                            (SPHEAT * onshoreDensity * onshoreVol);
     }
 
+ //fprintf(stdout, "###11 %f\n", Lake[5].Temp);
 
     /**************************************************************************
      * SURFACE MASS FLUXES (NO ICE COVER PRESENT)
@@ -1224,6 +1244,10 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
 
         recalc_surface_salt();
     }
+    
+    
+     //fprintf(stdout, "###12 %f\n", Lake[5].Temp);
+
 
     //# Recalculate densities
     for (i = botmLayer; i <= surfLayer; i++)
@@ -1268,6 +1292,9 @@ void do_surface_thermodynamics(int jday, int iclock, int LWModel,
         SurfData.delzSnow    = 0.0;
     }
     SurfData.RhoSnow = rho_snow;
+    
+     //fprintf(stdout, "###13 %f\n", Lake[5].Temp);
+
 
     free(LayerThickness);  free(heat);  free(layer_zone);
 


### PR DESCRIPTION
This addresses an issue where a variable needed in the outflow calculation is not defined when the outflow calculation is done before the deep mixing calculations in the sub-daily loop.  Outflow was moved before the sub-daily loop in the recent version of GLM to deal with an issue where inflow/outflow information is missing from single data runs.  This occurs because output writing output only occurs in the sub daily loop.  

The PR 
- moves inflow/outflows to after the sub-daily loop
- Add a check where output is not written on the last timestep within a day in the sub daily loop. 
- Adding a output writing step in the daily loop after inflow/outflow calculations.