### PR TITLE
crest height, seepage, and output writing updates

### DIFF
--- a/src/glm_flow.c
+++ b/src/glm_flow.c
@@ -482,7 +482,7 @@ AED_REAL do_outflows(int jday)
  * level.  Add in stack volumes when calculating overflow.                    *
  * After overflow, delete stack volumes from the structure.                   *
  ******************************************************************************/
-AED_REAL do_overflow(int jday)
+AED_REAL do_overflow(int jday, int startTOD, int stoptime)
 {
     AED_REAL VolSum = Lake[surfLayer].Vol1;
     AED_REAL DrawHeight = 0.;
@@ -501,7 +501,7 @@ AED_REAL do_overflow(int jday)
         AED_REAL ovfl_Q, ovfl_dz;
 
         ovfl_dz = MAX( Lake[surfLayer].Height - CrestHeight, zero );
-        ovfl_Q = 2./3. * crest_factor * pow(2*g,0.5) * crest_width * pow(ovfl_dz,1.5);
+        ovfl_Q = 2./3. * crest_factor * pow(2*g,0.5) * crest_width * pow(ovfl_dz,1.5) * (stoptime - startTOD);
         ovfl_Q  = MIN( (VolSum - VolAtCrest) , ovfl_Q );
 
         do_single_outflow(CrestHeight, ovfl_Q , NULL);

--- a/src/glm_flow.c
+++ b/src/glm_flow.c
@@ -405,7 +405,7 @@ void do_single_outflow(AED_REAL HeightOfOutflow, AED_REAL flow, OutflowDataType 
  * Loop through all outflows and process - return the difference between      *
  *  total volume before and after.                                            *
  ******************************************************************************/
-AED_REAL do_outflows(int jday)
+AED_REAL do_outflows(int jday, AED_REAL day_fraction)
 {
     int i;
     AED_REAL DrawHeight = -1; //# Height of withdraw [m from bottom]
@@ -461,12 +461,12 @@ AED_REAL do_outflows(int jday)
     if (seepage) {
         if (seepage_rate>zero) {
             // Darcy's Law used, so input rate is hydraulic conductivity (m/day) x hydraulic head
-            SeepDraw = seepage_rate * Lake[surfLayer].Height * Lake[surfLayer].LayerArea * 0.95;
+            SeepDraw = seepage_rate * Lake[surfLayer].Height * Lake[surfLayer].LayerArea * 0.95 * day_fraction;
         } else {
             // Constant seepage assumed, so input rate is dh (m/day)
             // 0.95 added since the effective area of seeping is probably
             // a bit less than max area of water innundation???
-            SeepDraw = -seepage_rate * Lake[surfLayer].LayerArea * 0.95;
+            SeepDraw = -seepage_rate * Lake[surfLayer].LayerArea * 0.95 * day_fraction;
       }
         do_single_outflow(0., SeepDraw, NULL);
     }
@@ -482,7 +482,7 @@ AED_REAL do_outflows(int jday)
  * level.  Add in stack volumes when calculating overflow.                    *
  * After overflow, delete stack volumes from the structure.                   *
  ******************************************************************************/
-AED_REAL do_overflow(int jday, int startTOD, int stoptime)
+AED_REAL do_overflow(int jday, AED_REAL day_fraction)
 {
     AED_REAL VolSum = Lake[surfLayer].Vol1;
     AED_REAL DrawHeight = 0.;
@@ -501,7 +501,7 @@ AED_REAL do_overflow(int jday, int startTOD, int stoptime)
         AED_REAL ovfl_Q, ovfl_dz;
 
         ovfl_dz = MAX( Lake[surfLayer].Height - CrestHeight, zero );
-        ovfl_Q = 2./3. * crest_factor * pow(2*g,0.5) * crest_width * pow(ovfl_dz,1.5) * (stoptime - startTOD);
+        ovfl_Q = 2./3. * crest_factor * pow(2*g,0.5) * crest_width * pow(ovfl_dz,1.5) * day_fraction * iSecsPerDay;
         ovfl_Q  = MIN( (VolSum - VolAtCrest) , ovfl_Q );
 
         do_single_outflow(CrestHeight, ovfl_Q , NULL);

--- a/src/glm_flow.h
+++ b/src/glm_flow.h
@@ -32,8 +32,8 @@
 
 #include "glm.h"
 
-AED_REAL do_outflows(int jday);
-AED_REAL do_overflow(int jday);
+AED_REAL do_outflows(int jday, AED_REAL day_fraction);
+AED_REAL do_overflow(int jday, AED_REAL day_fraction);
 AED_REAL do_inflows(void);
 
 #endif

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1569,7 +1569,7 @@ void initialise_lake(int namlst)
             Lake[i].Salinity = the_sals[i];
         }
 
-        if (the_heights[num_heights-1] > CrestHeight) {
+        if (the_heights[num_heights-1] > CrestHeight && restart_variables == NULL) {
             fprintf(stderr, "     ERROR: maximum height is greater than crest level\n");
             exit(1);
         }

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1570,7 +1570,12 @@ void initialise_lake(int namlst)
         }
 
         if (the_heights[num_heights-1] > CrestHeight && restart_variables == NULL) {
-            fprintf(stderr, "     ERROR: maximum height is greater than crest level\n");
+            fprintf(stderr, "     ERROR: initial first height of %f is greater than crest level of %f \n", the_heights[num_heights-1], CrestHeight);
+            exit(1);
+        }
+
+        if (the_heights[num_heights-1] > MaxHeight) {
+            fprintf(stderr, "     ERROR: initial first height of %f is greater than maximum height of %f \n", the_heights[num_heights-1], MaxHeight);
             exit(1);
         }
         num_depths = num_heights;

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1569,11 +1569,6 @@ void initialise_lake(int namlst)
             Lake[i].Salinity = the_sals[i];
         }
 
-        if (the_heights[num_heights-1] > CrestHeight && restart_variables == NULL) {
-            fprintf(stderr, "     ERROR: initial first height of %f is greater than crest level of %f \n", the_heights[num_heights-1], CrestHeight);
-            exit(1);
-        }
-
         if (the_heights[num_heights-1] > MaxHeight) {
             fprintf(stderr, "     ERROR: initial first height of %f is greater than maximum height of %f \n", the_heights[num_heights-1], MaxHeight);
             exit(1);

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -295,10 +295,10 @@ void do_model(int jstart, int nsave)
     read_daily_met(jstart, &MetOld);
     MetData = MetOld;
     SWold = MetOld.ShortWave;
+	
+    jday = jstart - 1;
 
     write_output(jday, SecsPerDay, nsave, stepnum);
-
-    jday = jstart - 1;
     /**************************************************************************
      * Loop over all days                                                     *
      **************************************************************************/
@@ -473,10 +473,10 @@ void do_model_non_avg(int jstart, int nsave)
     stepnum = 0;
     stoptime = iSecsPerDay;
     SWold = 0.;
+	
+    jday = jstart - 1;
 
     write_output(jday, SecsPerDay, nsave, stepnum);
-
-    jday = jstart - 1;
     /**************************************************************************
      * Loop over all days                                                     *
      **************************************************************************/
@@ -627,10 +627,12 @@ void do_model_coupled(int step_start, int step_end,
     stoptime = iSecsPerDay;
     SWold = 0.;
 
-    write_output(jday, SecsPerDay, nsave, stepnum);
+
 
     cDays = step_end - step_start + 1;
     jday = step_start - 1;
+
+     write_output(jday, SecsPerDay, nsave, stepnum);
     /**************************************************************************
      * Loop over all days                                                     *
      **************************************************************************/

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -274,6 +274,7 @@ void do_model(int jstart, int nsave)
     AED_REAL Elev[MaxInf];
     int jday, ntot, stepnum, stoptime;
     int i, j;
+    AED_REAL day_fraction;
 
     /*------------------------------------------------------------------------*/
 
@@ -378,10 +379,11 @@ void do_model(int jstart, int nsave)
         SurfData.dailyInflow = do_inflows(); //# Do inflow for all streams
 
         //# Extract withdrawal from all offtakes
-        SurfData.dailyOutflow = do_outflows(jday);
+        day_fraction = (stoptime - startTOD) / iSecsPerDay;
+        SurfData.dailyOutflow = do_outflows(jday, day_fraction);
 
         //# Take care of any overflow
-        SurfData.dailyOverflow = do_overflow(jday);
+        SurfData.dailyOverflow = do_overflow(jday, day_fraction);
 
         //# Enforce layer limits
         check_layer_thickness();
@@ -447,6 +449,7 @@ void do_model_non_avg(int jstart, int nsave)
     AED_REAL SWold, SWnew, DailyKw, DailyEvap;
     int jday, ntot, stepnum, stoptime;
     int i, j;
+    AED_REAL day_fraction;
 
    /***************************************************************************
     *CAB Note: these WQ arrays should be sized to Num_WQ_Vars not MaxVars,    *
@@ -534,11 +537,12 @@ void do_model_non_avg(int jstart, int nsave)
         SurfData.dailyInflow = do_inflows();
 
         if (Lake[surfLayer].Vol1 > zero) {
-            //# Extract withdrawal from all offtakes
-            SurfData.dailyOutflow = do_outflows(jday);
+           //# Extract withdrawal from all offtakes
+           day_fraction = (stoptime - startTOD) / iSecsPerDay;
+           SurfData.dailyOutflow = do_outflows(jday, day_fraction);
 
-            //# Take care of any overflow
-            SurfData.dailyOverflow = do_overflow(jday);
+           //# Take care of any overflow
+           SurfData.dailyOverflow = do_overflow(jday, day_fraction);
         }
 
         //# Enforce layer limits
@@ -599,7 +603,8 @@ void do_model_coupled(int step_start, int step_end,
     AED_REAL WQNew[MaxInf * MaxVars];
     int jday, ntot, stepnum, stoptime, cDays;
     int i, j;
-
+    AED_REAL day_fraction;    
+        
     /*------------------------------------------------------------------------*/
     memset(WQNew, 0, sizeof(AED_REAL)*MaxInf*MaxVars);
 
@@ -675,11 +680,12 @@ void do_model_coupled(int step_start, int step_end,
         SurfData.dailyInflow = do_inflows();
 
         if (Lake[surfLayer].Vol1 > zero) {
-            //# Extract withdrawal from all offtakes
-            SurfData.dailyOutflow = do_outflows(jday);
+           //# Extract withdrawal from all offtakes
+           day_fraction = (stoptime - startTOD) / iSecsPerDay;
+           SurfData.dailyOutflow = do_outflows(jday, day_fraction);
 
-            //# Take care of any overflow
-            SurfData.dailyOverflow = do_overflow(jday);
+           //# Take care of any overflow
+           SurfData.dailyOverflow = do_overflow(jday, day_fraction);
         }
 
         //# Enforce layer limits

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -296,6 +296,8 @@ void do_model(int jstart, int nsave)
     MetData = MetOld;
     SWold = MetOld.ShortWave;
 
+    write_output(jday, SecsPerDay, nsave, stepnum);
+
     jday = jstart - 1;
     /**************************************************************************
      * Loop over all days                                                     *
@@ -472,6 +474,8 @@ void do_model_non_avg(int jstart, int nsave)
     stoptime = iSecsPerDay;
     SWold = 0.;
 
+    write_output(jday, SecsPerDay, nsave, stepnum);
+
     jday = jstart - 1;
     /**************************************************************************
      * Loop over all days                                                     *
@@ -622,6 +626,8 @@ void do_model_coupled(int step_start, int step_end,
     stepnum = 0;
     stoptime = iSecsPerDay;
     SWold = 0.;
+
+    write_output(jday, SecsPerDay, nsave, stepnum);
 
     cDays = step_end - step_start + 1;
     jday = step_start - 1;

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -307,6 +307,7 @@ void do_model(int jstart, int nsave)
         //# If it is the last day, adjust the stop time for the day if necessary
         if (ntot == nDates) stoptime = stopTOD;
         if (stoptime == 0) break;
+        day_fraction = (stoptime - startTOD) / iSecsPerDay;
 
         //# Initialise daily values for volume & heat balance reporting (lake.csv)
         SurfData.dailyRain = 0.; SurfData.dailyEvap = 0.;
@@ -327,7 +328,7 @@ void do_model(int jstart, int nsave)
         //# (stoptime - startTOD) allow for partial dates at the the beginning and end of
         //# simulation
         for (i = 0; i < NumInf; i++) {
-            Inflows[i].FlowRate = (FlowOld[i] + FlowNew[i]) / 2.0 * (stoptime - startTOD) ;
+            Inflows[i].FlowRate = (FlowOld[i] + FlowNew[i]) / 2.0 * day_fraction * iSecsPerDay;
             Inflows[i].TemInf   = (TempOld[i] + TempNew[i]) / 2.0;
             Inflows[i].SalInf   = (SaltOld[i] + SaltNew[i]) / 2.0;
             Inflows[i].SubmElev = Elev[i];
@@ -341,7 +342,7 @@ void do_model(int jstart, int nsave)
         read_daily_outflow(jday, NumOut, DrawNew);
         //# To get daily outflow (i.e. m3/day) times by the seconds in the current day
         for (i = 0; i < NumOut; i++)
-            Outflows[i].Draw = (DrawOld[i] + DrawNew[i]) / 2.0 * (stoptime - startTOD) ;
+            Outflows[i].Draw = (DrawOld[i] + DrawNew[i]) / 2.0 * day_fraction * iSecsPerDay ;
 
         read_daily_withdraw_temp(jday, &WithdrTempNew);
         WithdrawalTemp = (WithdrTempOld + WithdrTempNew) / 2.0;
@@ -379,7 +380,6 @@ void do_model(int jstart, int nsave)
         SurfData.dailyInflow = do_inflows(); //# Do inflow for all streams
 
         //# Extract withdrawal from all offtakes
-        day_fraction = (stoptime - startTOD) / iSecsPerDay;
         SurfData.dailyOutflow = do_outflows(jday, day_fraction);
 
         //# Take care of any overflow
@@ -480,6 +480,7 @@ void do_model_non_avg(int jstart, int nsave)
         //# If it is the last day, adjust the stop time for the day if necessary
         if (ntot == nDates) stoptime = stopTOD;
         if (stoptime == 0) break;
+        day_fraction = (stoptime - startTOD) / iSecsPerDay;
 
         //# Initialise daily values for volume & heat balance reporting (lake.csv)
         SurfData.dailyRain    = 0.; SurfData.dailyEvap     = 0.;
@@ -498,7 +499,7 @@ void do_model_non_avg(int jstart, int nsave)
 
         //# To get daily inflow (i.e. m3/day) times by SecsPerDay
         for (i = 0; i < NumInf; i++) {
-            Inflows[i].FlowRate = FlowNew[i] * (stoptime - startTOD) ;
+            Inflows[i].FlowRate = FlowNew[i] * day_fraction * iSecsPerDay;
             Inflows[i].TemInf   = TempNew[i];
             Inflows[i].SalInf   = SaltNew[i];
             Inflows[i].SubmElev = Elev[i];
@@ -514,7 +515,7 @@ void do_model_non_avg(int jstart, int nsave)
         //# (stoptime - startTOD) allow for partial dates at the the beginning and end of
         //# simulation
         for (i = 0; i < NumOut; i++)
-            Outflows[i].Draw = DrawNew[i] * (stoptime - startTOD) ;
+            Outflows[i].Draw = DrawNew[i] * day_fraction * iSecsPerDay ;
 
         read_daily_withdraw_temp(jday, &WithdrTempNew);
         WithdrawalTemp = WithdrTempNew;
@@ -538,7 +539,6 @@ void do_model_non_avg(int jstart, int nsave)
 
         if (Lake[surfLayer].Vol1 > zero) {
            //# Extract withdrawal from all offtakes
-           day_fraction = (stoptime - startTOD) / iSecsPerDay;
            SurfData.dailyOutflow = do_outflows(jday, day_fraction);
 
            //# Take care of any overflow
@@ -628,6 +628,7 @@ void do_model_coupled(int step_start, int step_end,
         //# If it is the last day, adjust the stop time for the day if necessary
         if (ntot == nDates) stoptime = stopTOD;
         if (stoptime == 0) break;
+        day_fraction = (stoptime - startTOD) / iSecsPerDay;
 
         //# Initialise daily values for volume & heat balance reporting (lake.csv)
         SurfData.dailyRain = 0.; SurfData.dailyEvap = 0.;
@@ -645,7 +646,7 @@ void do_model_coupled(int step_start, int step_end,
         //# (stoptime - startTOD) allow for partial dates at the the beginning and end of
         //# simulation
         for (i = 0; i < NumInf; i++) {
-            Inflows[i].FlowRate = FlowNew[i] * (stoptime - startTOD);
+            Inflows[i].FlowRate = FlowNew[i] * day_fraction * iSecsPerDay;
 //          Inflows[i].TemInf   = TempNew[i];
 //          Inflows[i].SalInf   = SaltNew[i];
             for (j = 0; j < Num_WQ_Vars; j++) {
@@ -657,7 +658,7 @@ void do_model_coupled(int step_start, int step_end,
     //  read_daily_outflow(jday, NumOut, DrawNew);
         //# To get daily outflow (i.e. m3/day) times by SecsPerDay
         for (i = 0; i < NumOut; i++)
-            Outflows[i].Draw = DrawNew[i] * (stoptime - startTOD);
+            Outflows[i].Draw = DrawNew[i] * day_fraction * iSecsPerDay;
 
     //  read_daily_withdraw_temp(jday, &WithdrTempNew);
     //  WithdrawalTemp = WithdrTempNew;
@@ -681,7 +682,6 @@ void do_model_coupled(int step_start, int step_end,
 
         if (Lake[surfLayer].Vol1 > zero) {
            //# Extract withdrawal from all offtakes
-           day_fraction = (stoptime - startTOD) / iSecsPerDay;
            SurfData.dailyOutflow = do_outflows(jday, day_fraction);
 
            //# Take care of any overflow


### PR DESCRIPTION
This PR addresses the following

- overland flow through a weir was calculated as m3/s instead of the m3/day that is required by the do_single_outflow function. 
- The PR fixes this by adding a new internal variable called day_fraction that is the proportion of a day that cover by the current day of the simulation. A mid-night to mid-night simulation has a day_fraction = 1.0. day_fraction can be multiplied by the number of seconds in a day to get the number of seconds in the current day of the simulation.
- seepage was also m3/s so needed to be coverted to m3/day
- there was a check as initalization that compare the height of the top layer to the crest elevation. The checked needed to compare to the max elevation since it is possible to have water higher than a weir elevation (which is what the crest elevation represents).
- fixed an issue where multiple values for the same time-step would occur in the netcdf output when starting on non 00:00 hours (so the last day was not a full day).
- This PR now includes an additional write_output step that occurs before the daily loop. This allows the initial conditions to be reflected in the model output.