### PR TITLE
Include WQD_Vars in lake volume updates

### DIFF
--- a/src/glm_layers.c
+++ b/src/glm_layers.c
@@ -140,6 +140,9 @@ void check_layer_thickness(void)
         for (wqidx = 0; wqidx < Num_WQ_Vars; wqidx++)
             _WQ_Vars(wqidx,j) = combine_vol(_WQ_Vars(wqidx,j), Lake[j].LayerVol, _WQ_Vars(wqidx,j+1), Lake[j+1].LayerVol);
 
+        for (wqidx = 0; wqidx < Num_WQD_Vars; wqidx++)
+            _WQD_Vars(wqidx,j) = combine_vol(_WQD_Vars(wqidx,j), Lake[j].LayerVol, _WQD_Vars(wqidx,j+1), Lake[j+1].LayerVol);
+        
         Lake[j].Density = calculate_density(Lake[j].Temp, Lake[j].Salinity);
         Lake[j].LayerVol = Lake[j].LayerVol + Lake[j+1].LayerVol;
         Lake[j].Height = Lake[j+1].Height;
@@ -160,6 +163,9 @@ void check_layer_thickness(void)
 
                 for (wqidx=0; wqidx < Num_WQ_Vars; wqidx++)
                     _WQ_Vars(wqidx, k) = _WQ_Vars(wqidx, k+1);
+
+                for (wqidx=0; wqidx < Num_WQD_Vars; wqidx++)
+                    _WQD_Vars(wqidx, k) = _WQD_Vars(wqidx, k+1);
 
                 Lake[k].LayerVol = Lake[k+1].LayerVol;
                 Lake[k].Vol1 = Lake[k+1].Vol1;


### PR DESCRIPTION
When examining subdaily output from the PTM, @melofton noticed that water quality diagnostic variable jump depths at the end of the day and end of the simulation. They look reasonable at other times and the water quality states are fine.  I determined that it is due to water quality diagnostics not receiving the same treatment as water quality variables in the `check_layer_thinkness()` function call.  This PR fixes the issue.   