### PR TITLE
Added a netcdf restart

### DIFF
--- a/src/glm_aed.F90
+++ b/src/glm_aed.F90
@@ -317,6 +317,7 @@ SUBROUTINE aed_init_glm(i_fname, len, NumWQ_Vars, NumWQ_Ben)                   &
    cc = 0.         !# initialise to zero
 
    CALL set_c_wqvars_ptr(cc)
+   IF (n_vars_ben > 0) CALL set_c_wqsvars_ptr(cc(n_vars+1, 1))
 
    print "(5X,'Configured AED variables to simulate:')"
 
@@ -1655,6 +1656,46 @@ INTEGER FUNCTION WQVar_Index(name)
    ENDDO
    WQVar_Index = -1
 END FUNCTION WQVar_Index
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+!###############################################################################
+SUBROUTINE aed_get_var_names(wbuf, wlen, bbuf, blen) BIND(C, name="aed_get_var_names")
+!-------------------------------------------------------------------------------
+! Fill comma-separated C strings with all water-column and benthic WQ state
+! variable names in their AED index order (matching rows of wq_vars / wqs_vars).
+!-------------------------------------------------------------------------------
+!ARGUMENTS
+   CCHARACTER, INTENT(out) :: wbuf(*), bbuf(*)
+   CINTEGER,   INTENT(out) :: wlen, blen
+!LOCALS
+   TYPE(aed_variable_t), POINTER :: tvar
+   INTEGER :: i, j, nlen, w, b
+!
+!-------------------------------------------------------------------------------
+!BEGIN
+   w = 0 ; b = 0
+   DO i=1,n_aed_vars
+      IF ( aed_get_var(i, tvar) ) THEN
+         IF ( tvar%var_type == V_STATE ) THEN
+            nlen = LEN_TRIM(tvar%name)
+            IF ( .NOT. tvar%sheet ) THEN
+               IF (w > 0) THEN ; wbuf(w+1) = ',' ; w = w+1 ; ENDIF
+               DO j=1,nlen ; wbuf(w+j) = tvar%name(j:j) ; ENDDO
+               w = w + nlen
+            ELSE
+               IF (b > 0) THEN ; bbuf(b+1) = ',' ; b = b+1 ; ENDIF
+               DO j=1,nlen ; bbuf(b+j) = tvar%name(j:j) ; ENDDO
+               b = b + nlen
+            ENDIF
+         ENDIF
+      ENDIF
+   ENDDO
+   wbuf(w+1) = ACHAR(0)
+   bbuf(b+1) = ACHAR(0)
+   wlen = w
+   blen = b
+END SUBROUTINE aed_get_var_names
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 

--- a/src/glm_api_aed.F90
+++ b/src/glm_api_aed.F90
@@ -226,6 +226,7 @@ SUBROUTINE api_init_glm(i_fname, len, NumWQ_Vars, NumWQ_Ben)                   &
 
    NumWQ_Vars  = n_vars
    NumWQ_Ben   = n_vars_ben
+   CALL set_c_num_ptm_vars(n_ptm_vars)
 
    ALLOCATE(plot_id_v(n_vars))
    ALLOCATE(plot_id_sv(n_vars_ben))
@@ -420,6 +421,7 @@ SUBROUTINE api_set_glm_data()                     BIND(C, name=_WQ_SET_GLM_DATA)
    CALL set_c_wqvars_ptr(cc)
 
    cc_hz => cc(n_vars+1:n_vars+n_vars_ben, 1)
+   IF (n_vars_ben > 0) CALL set_c_wqsvars_ptr(cc_hz)
 
    !# Allocate diagnostic variable array and set all values to zero.
    !# (needed because time-integrated/averaged variables will increment rather than set the array)
@@ -848,6 +850,46 @@ CINTEGER FUNCTION aed_var_index_c(name, len)       BIND(C, name=_WQ_VAR_INDEX_C)
    tn = trim(transfer(name(1:len),tn))
    aed_var_index_c = aed_var_index(tn) - 1
 END FUNCTION aed_var_index_c
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+!###############################################################################
+SUBROUTINE api_get_var_names(wbuf, wlen, bbuf, blen) BIND(C, name="api_get_var_names")
+!-------------------------------------------------------------------------------
+! Fill comma-separated C strings with all water-column and benthic WQ state
+! variable names in their AED index order (matching rows of wq_vars / wqs_vars).
+!-------------------------------------------------------------------------------
+!ARGUMENTS
+   CCHARACTER, INTENT(out) :: wbuf(*), bbuf(*)
+   CINTEGER,   INTENT(out) :: wlen, blen
+!LOCALS
+   TYPE(aed_variable_t), POINTER :: tvar
+   INTEGER :: i, j, nlen, w, b
+!
+!-------------------------------------------------------------------------------
+!BEGIN
+   w = 0 ; b = 0
+   DO i=1,n_aed_vars
+      IF ( aed_get_var(i, tvar) ) THEN
+         IF ( tvar%var_type == V_STATE ) THEN
+            nlen = LEN_TRIM(tvar%name)
+            IF ( .NOT. tvar%sheet ) THEN
+               IF (w > 0) THEN ; wbuf(w+1) = ',' ; w = w+1 ; ENDIF
+               DO j=1,nlen ; wbuf(w+j) = tvar%name(j:j) ; ENDDO
+               w = w + nlen
+            ELSE
+               IF (b > 0) THEN ; bbuf(b+1) = ',' ; b = b+1 ; ENDIF
+               DO j=1,nlen ; bbuf(b+j) = tvar%name(j:j) ; ENDDO
+               b = b + nlen
+            ENDIF
+         ENDIF
+      ENDIF
+   ENDDO
+   wbuf(w+1) = ACHAR(0)
+   bbuf(b+1) = ACHAR(0)
+   wlen = w
+   blen = b
+END SUBROUTINE api_get_var_names
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 END MODULE glm_api_aed

--- a/src/glm_globals.c
+++ b/src/glm_globals.c
@@ -281,6 +281,7 @@ AED_REAL *WQDS_Vars = NULL;  //# water quality diagnostic benthic array, [nvars]
 
 int *PTM_Stat = NULL;  //# water quality array, [nlayers, nvars]
 AED_REAL *PTM_Vars = NULL;  //# water quality array, [nlayers, nvars]
+int Num_PTM_Vars = 0;  //# number of AED particle-tracked WQ variables (n_ptm_vars)
 
 //------------------------------------------------------------------------------
 //  These for debugging
@@ -289,12 +290,14 @@ CLOGICAL dbg_mix = FALSE;   //# debug output from mixer
 CLOGICAL no_evap = FALSE;   //# turn off evaporation
 int      quiet   = 0;       //# turn down output messages
 
-void set_c_wqvars_ptr(AED_REAL *iwqv) { WQ_Vars = iwqv; }
+void set_c_wqvars_ptr(AED_REAL *iwqv)  { WQ_Vars  = iwqv; }
+void set_c_wqsvars_ptr(AED_REAL *iwqsv) { WQS_Vars = iwqsv; }
 void set_c_wqdvars_ptr(AED_REAL *iwqd, AED_REAL *iwqds, int *nwqd, int *nwqds)
 { WQD_Vars = iwqd; WQDS_Vars = iwqds; Num_WQD_Vars = *nwqd; Num_WQDS_Vars = *nwqds; }
 
 void set_c_ptmstat_ptr(int *iptms) { PTM_Stat = iptms; }
 void set_c_ptmenv_ptr(AED_REAL *iptmv) { PTM_Vars = iptmv; }
+void set_c_num_ptm_vars(int *n) { Num_PTM_Vars = *n; }
 
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 

--- a/src/glm_globals.h
+++ b/src/glm_globals.h
@@ -43,6 +43,11 @@
         AED_REAL,INTENT(in) :: iwqvars(*)
      END SUBROUTINE set_c_wqvars_ptr
 
+     SUBROUTINE set_c_wqsvars_ptr(iwqsvars) BIND(C, name="set_c_wqsvars_ptr")
+        USE ISO_C_BINDING
+        AED_REAL,INTENT(in) :: iwqsvars(*)
+     END SUBROUTINE set_c_wqsvars_ptr
+
      SUBROUTINE set_c_wqdvars_ptr(iwqdvars,iwqdsvars,nwqd,nwqds) BIND(C, name="set_c_wqdvars_ptr")
         USE ISO_C_BINDING
 #       if defined( _WIN32 ) && USE_DL_LOADER
@@ -69,6 +74,11 @@
 #       endif
         AED_REAL,INTENT(in) :: iptmv(*)
      END SUBROUTINE set_c_ptmenv_ptr
+
+     SUBROUTINE set_c_num_ptm_vars(n) BIND(C, name="set_c_num_ptm_vars")
+        USE ISO_C_BINDING
+        CINTEGER,INTENT(in) :: n
+     END SUBROUTINE set_c_num_ptm_vars
 
 # if DEBUG
      SUBROUTINE debug_print_lake() BIND(C, name="debug_print_lake")
@@ -326,6 +336,7 @@ extern AED_REAL settling_efficiency;
 extern AED_REAL *inflow_conc;  //# concentration of particles per ?? in the inflow
 
 extern partgroup *Particles;
+extern int Num_PTM_Vars;  //# number of AED particle-tracked WQ variables (n_ptm_vars)
 
 /*----------------------------------------------------------------------------*/
 // TIME
@@ -393,9 +404,11 @@ extern AED_REAL Latitude;
 /******************************************************************************/
 void allocate_storage(void);
 void set_c_wqvars_ptr(AED_REAL *iwqvars);
+void set_c_wqsvars_ptr(AED_REAL *iwqsvars);
 void set_c_wqdvars_ptr(AED_REAL *iwqd, AED_REAL *iwqds, int *nwqd, int *nwqds);
 void set_c_ptmstat_ptr(int *iptms);
 void set_c_ptmenv_ptr(AED_REAL *iptmv);
+void set_c_num_ptm_vars(int *n);
 void debug_print_lake(void);
 void debug_initialisation(int which);
 void debug_initialisation_(int *which);

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -1668,9 +1668,6 @@ void initialise_lake(int namlst)
     AED_REAL        snow_thickness = 0.0;
     AED_REAL        white_ice_thickness = 0.0;
     AED_REAL        blue_ice_thickness = 0.0;
-    AED_REAL        avg_surf_temp = 6.0;
-    AED_REAL       *restart_variables = NULL;
-    int             restart_mixer_count;
     char           *init_restart_fname     = NULL;
     int             init_restart_from_file = 0;
 
@@ -1690,9 +1687,6 @@ void initialise_lake(int namlst)
           { "snow_thickness",         TYPE_DOUBLE,           &snow_thickness        },
           { "white_ice_thickness",    TYPE_DOUBLE,           &white_ice_thickness   },
           { "blue_ice_thickness",     TYPE_DOUBLE,           &blue_ice_thickness    },
-          { "avg_surf_temp",          TYPE_DOUBLE,           &avg_surf_temp         },
-          { "restart_variables",      TYPE_DOUBLE|MASK_LIST, &restart_variables     },
-          { "restart_mixer_count",    TYPE_INT,              &restart_mixer_count   },
           { "init_restart_fname",      TYPE_STR,              &init_restart_fname     },
           { "init_restart_from_file", TYPE_INT,              &init_restart_from_file},
           { NULL,                     TYPE_END,              NULL                   }
@@ -1702,7 +1696,6 @@ void initialise_lake(int namlst)
     int i, j, min_layers;
     int nx, np, nz;
     int *idx = NULL;
-    CLOGICAL need_free = FALSE;
 
 /*----------------------------------------------------------------------------*/
     //-------------------------------------------------
@@ -1786,37 +1779,29 @@ void initialise_lake(int namlst)
     if (min_layers > 50) min_layers = 50;
     if (min_layers < 3) min_layers = 3;
 
-    if (restart_variables == NULL) {
-        need_free = TRUE;
-        restart_variables = calloc(17, sizeof(AED_REAL));
-
-        // Now interpolate into at least min_layers
-        while (NumLayers <= min_layers) {
-            for (i = botmLayer; i < NumLayers; i++) {
-                nx = 2 * (surfLayer - i);
-                np = surfLayer - i;
-                Lake[nx].Height = Lake[np].Height;
-                Lake[nx].Temp = Lake[np].Temp;
-                Lake[nx].Salinity = Lake[np].Salinity;
-                for (j = 0; j < num_wq_vars; j++)
-                    if ( idx[j] >= 0 ) _WQ_Vars(idx[j],nx) = _WQ_Vars(idx[j],np);
-            }
-            for (i = botmLayer+1; i < NumLayers; i++) {
-                nx = 2 * i - 1;
-                np = 2 * i - 2;
-                nz = 2 * i - 0;
-                Lake[nx].Temp = (Lake[np].Temp + Lake[nz].Temp) / 2.0;
-                Lake[nx].Height = (Lake[np].Height + Lake[nz].Height) / 2.0;
-                Lake[nx].Salinity = (Lake[np].Salinity + Lake[nz].Salinity) / 2.0;
-                for (j = 0; j < num_wq_vars; j++)
-                    if ( idx[j] >= 0 ) _WQ_Vars(idx[j],nx) = (_WQ_Vars(idx[j],np) + _WQ_Vars(idx[j],nz)) / 2.0;
-            }
-            NumLayers = 2*NumLayers - 1;
-            if ( NumLayers * 2 >= MaxLayers ) break;
+    // Now interpolate into at least min_layers
+    while (NumLayers <= min_layers) {
+        for (i = botmLayer; i < NumLayers; i++) {
+            nx = 2 * (surfLayer - i);
+            np = surfLayer - i;
+            Lake[nx].Height = Lake[np].Height;
+            Lake[nx].Temp = Lake[np].Temp;
+            Lake[nx].Salinity = Lake[np].Salinity;
+            for (j = 0; j < num_wq_vars; j++)
+                if ( idx[j] >= 0 ) _WQ_Vars(idx[j],nx) = _WQ_Vars(idx[j],np);
         }
-    } else {
-        // Use the layers exactly as provided in the nml (used in restarting)
-        NumLayers = num_depths;
+        for (i = botmLayer+1; i < NumLayers; i++) {
+            nx = 2 * i - 1;
+            np = 2 * i - 2;
+            nz = 2 * i - 0;
+            Lake[nx].Temp = (Lake[np].Temp + Lake[nz].Temp) / 2.0;
+            Lake[nx].Height = (Lake[np].Height + Lake[nz].Height) / 2.0;
+            Lake[nx].Salinity = (Lake[np].Salinity + Lake[nz].Salinity) / 2.0;
+            for (j = 0; j < num_wq_vars; j++)
+                if ( idx[j] >= 0 ) _WQ_Vars(idx[j],nx) = (_WQ_Vars(idx[j],np) + _WQ_Vars(idx[j],nz)) / 2.0;
+        }
+        NumLayers = 2*NumLayers - 1;
+        if ( NumLayers * 2 >= MaxLayers ) break;
     }
 
     // And free the temporary index map
@@ -1844,32 +1829,6 @@ void initialise_lake(int namlst)
     if (deep_mixing == 1) {     // constant diffusivity over whole water column
         for (i = 0; i < NumLayers; i++)
           Lake[i].Epsilon = coef_mix_hyp;
-    }
-
-    AvgSurfTemp = avg_surf_temp;
-
-    if (restart_variables != NULL) {
-        DepMX = restart_variables[0];
-        PrevThick =  restart_variables[1]; //# mixed layer thickness from previous time step
-        gPrimeTwoLayer =  restart_variables[2]; //# Reduced gravity for int wave estimate
-        Energy_AvailableMix = restart_variables[3];  //# Total available energy to mix (carries over from previous timesteps)
-        Mass_Epi =  restart_variables[4];//# Sigma mass of Epilimnion (surface layer after Kelvin-Helmholtz) kg
-        OldSlope = restart_variables[5];
-        Time_end_shear =  restart_variables[6]; //# Time left before shear cut off [hours]
-        Time_start_shear =  restart_variables[7];//# Time count since start of sim for shear period start [hours]
-        Time_count_end_shear =  restart_variables[8]; //# Time count since start of sim for shear period end [hours]
-        Time_count_sim = restart_variables[9];  //# Time count since start of simulation [hours]
-        Half_Seiche_Period = restart_variables[10];//# One half the seiche period
-        Thermocline_Height =  restart_variables[11];//# Height at the top of the metalimnion [m]
-        FO = restart_variables[12];
-        FSUM = restart_variables[13];
-        u_f = restart_variables[14];
-        u0 = restart_variables[15];
-        u_avg = restart_variables[16];
-
-        Mixer_Count = restart_mixer_count;
-
-        if (need_free) free(restart_variables);
     }
 
     /* Load state from a NetCDF restart file if requested via init_profiles. */

--- a/src/glm_init.c
+++ b/src/glm_init.c
@@ -211,8 +211,8 @@ void init_glm(int *jstart, char *outp_dir, char *outp_fn, int *nsave)
          { "out_dir",             TYPE_STR,              &out_dir             },
          { "out_fn",              TYPE_STR,              &out_fn              },
          { "nsave",               TYPE_INT,               nsave               },
-         { "rst_fn",              TYPE_STR,              &local_rst_fn        },
-         { "rst_nsave",           TYPE_INT,              &local_rst_nsave     },
+         { "restart_fname",              TYPE_STR,              &local_rst_fn        },
+         { "restart_nsave",           TYPE_INT,              &local_rst_nsave     },
          { "csv_point_nlevs",     TYPE_INT,              &csv_point_nlevs     },
          { "csv_point_fname",     TYPE_STR,              &csv_point_fname     },
          { "csv_point_frombot",   TYPE_BOOL|MASK_LIST,   &csv_point_frombot   },
@@ -774,9 +774,9 @@ void init_glm(int *jstart, char *outp_dir, char *outp_fn, int *nsave)
 
     /* Store restart configuration into module globals */
     if (local_rst_fn != NULL) {
-        rst_fn = strdup(local_rst_fn);
+        restart_fname = strdup(local_rst_fn);
     }
-    rst_nsave = local_rst_nsave;
+    restart_nsave = local_rst_nsave;
 
     if ( csv_point_nlevs > MaxPointCSV ) { fprintf(stderr, "csv_point_nlevs must be < %d\n", MaxPointCSV); exit(1); }
     if ( csv_point_nvars > MaxCSVOutVars ) { fprintf(stderr, "csv_point_nvars must be < %d\n", MaxCSVOutVars); exit(1); }
@@ -1671,7 +1671,7 @@ void initialise_lake(int namlst)
     AED_REAL        avg_surf_temp = 6.0;
     AED_REAL       *restart_variables = NULL;
     int             restart_mixer_count;
-    char           *init_restart_file     = NULL;
+    char           *init_restart_fname     = NULL;
     int             init_restart_from_file = 0;
 
     //==========================================================================
@@ -1693,7 +1693,7 @@ void initialise_lake(int namlst)
           { "avg_surf_temp",          TYPE_DOUBLE,           &avg_surf_temp         },
           { "restart_variables",      TYPE_DOUBLE|MASK_LIST, &restart_variables     },
           { "restart_mixer_count",    TYPE_INT,              &restart_mixer_count   },
-          { "init_restart_file",      TYPE_STR,              &init_restart_file     },
+          { "init_restart_fname",      TYPE_STR,              &init_restart_fname     },
           { "init_restart_from_file", TYPE_INT,              &init_restart_from_file},
           { NULL,                     TYPE_END,              NULL                   }
     };
@@ -1873,11 +1873,11 @@ void initialise_lake(int namlst)
     }
 
     /* Load state from a NetCDF restart file if requested via init_profiles. */
-    if (init_restart_from_file != 0 && init_restart_file != NULL) {
-        if (read_glm_restart(init_restart_file))
-            fprintf(stderr, "     Restart state loaded from %s\n", init_restart_file);
+    if (init_restart_from_file != 0 && init_restart_fname != NULL) {
+        if (read_glm_restart(init_restart_fname))
+            fprintf(stderr, "     Restart state loaded from %s\n", init_restart_fname);
         else
-            fprintf(stderr, "     WARNING: init_restart_from_file set but could not read '%s'; using profile init\n", init_restart_file);
+            fprintf(stderr, "     WARNING: init_restart_from_file set but could not read '%s'; using profile init\n", init_restart_fname);
     }
 }
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -950,7 +950,7 @@ void end_model()
     close_output();
 
     /* Write the final NetCDF restart file if configured */
-    if (rst_fn != NULL)
-        write_glm_restart(rst_fn);
+    if (restart_fname != NULL)
+        write_glm_restart(restart_fname);
 }
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/

--- a/src/glm_ncdf.c
+++ b/src/glm_ncdf.c
@@ -45,23 +45,19 @@ int ncid=-1;
 static int set_no = -1;
 
 //# dimension sizes
-int x_dim, y_dim, z_dim, zone_dim, time_dim, restart_dim, ptm_dim;
+int x_dim, y_dim, z_dim, zone_dim, time_dim, ptm_dim;
 
 //# dimension lengths
 static int lon_len=1;
 static int lat_len=1;
 static int height_len;
-static int restart_len = 17;
-
 static size_t start[4],edges[4];
-
-static size_t start_r[1],edges_r[1];
 
 //# variable ids
 static int lon_id, lat_id, z_id, H_id, V_id, A_id, TV_id, Taub_id, NS_id, time_id;
-static int SL_id, HICE_id, HSNOW_id, HWICE_id, AvgSurfTemp_id;
+static int SL_id, HICE_id, HSNOW_id, HWICE_id;
 static int precip_id, evap_id, rho_id, rad_id, extc_id, i0_id, wnd_id;
-static int temp_id, salt_id, umean_id, uorb_id, restart_id, Mixer_Count_id, epsilon_id;
+static int temp_id, salt_id, umean_id, uorb_id, epsilon_id;
 
 //# from lake.csv
 static int SA_id, VSnow_id,VBIce_id,VWIce_id, TotInVol_id, TotOutVol_id;
@@ -105,7 +101,6 @@ int init_glm_ncdf(const char *fn, const char *title, AED_REAL lat,
     check_nc_error(nc_def_dim(ncid, "lon", 1, &x_dim));
     check_nc_error(nc_def_dim(ncid, "lat", 1, &y_dim));
     check_nc_error(nc_def_dim(ncid, "z", nlev, &z_dim));
-    check_nc_error(nc_def_dim(ncid, "restart", 17, &restart_dim));
     check_nc_error(nc_def_dim(ncid, "particle", 1000000, &ptm_dim));
 
     if ( n_zones > 0 )
@@ -126,11 +121,6 @@ int init_glm_ncdf(const char *fn, const char *title, AED_REAL lat,
     check_nc_error(nc_def_var(ncid, "snow_thickness",      NC_REALTYPE, 1, dims, &HSNOW_id));
     check_nc_error(nc_def_var(ncid, "white_ice_thickness", NC_REALTYPE, 1, dims, &HWICE_id));
     check_nc_error(nc_def_var(ncid, "surface_layer",       NC_INT,      1, dims, &SL_id));
-    check_nc_error(nc_def_var(ncid, "avg_surf_temp",       NC_REALTYPE, 1, dims, &AvgSurfTemp_id));
-    check_nc_error(nc_def_var(ncid, "Mixer_Count",         NC_INT,      1, dims, &Mixer_Count_id));
-
-    dims[0] = restart_dim;
-    check_nc_error(nc_def_var(ncid, "restart_variables", NC_REALTYPE, 1, dims, &restart_id));
 
     /**************************************************************************
      * define 2D variables                                                    *
@@ -224,12 +214,6 @@ int init_glm_ncdf(const char *fn, const char *title, AED_REAL lat,
     set_nc_attributes(ncid, HICE_id,   "meters",  "Height of Ice"   PARAM_FILLVALUE);
     set_nc_attributes(ncid, HSNOW_id,  "meters",  "Height of Snow"  PARAM_FILLVALUE);
     set_nc_attributes(ncid, HWICE_id,  "meters",  "Height of WhiteIce" PARAM_FILLVALUE);
-    set_nc_attributes(ncid, AvgSurfTemp_id,  "celsius",  "Running average surface temperature" PARAM_FILLVALUE);
-
-    set_nc_attributes(ncid, restart_id,  "various",  "dep_mx,prev_thick,g_prime_two_layer,\
-energy_avail_max,mass_epi,old_slope,time_end_shear,time_start_shear,\
-time_count_end,time_count_sim,half_seiche_period,thermocline_height,\
-f0, fsum,u_f,u0,u_avg" PARAM_FILLVALUE);
 
     //# x,y,t
     set_nc_attributes(ncid, precip_id, "m/s",     "precipitation"   PARAM_FILLVALUE);
@@ -322,7 +306,7 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
 {
     AED_REAL temp_time, LakeVolume;
     AED_REAL *heights, *vols, *area, *salts, *temps, *dens, *qsw, *extc_coef;
-    AED_REAL *u_mean, *u_orb, *taub, *restart_variables, *epsilon;
+    AED_REAL *u_mean, *u_orb, *taub, *epsilon;
     int i, littoralLayer = 0, iret = NC_NOERR;
 
     if (ncid == -1) return;
@@ -343,7 +327,6 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
     store_nc_scalar(ncid,  HICE_id, T_SHAPE, SurfData.delzBlueIce);
     store_nc_scalar(ncid, HWICE_id, T_SHAPE, SurfData.delzWhiteIce);
     store_nc_scalar(ncid, HSNOW_id, T_SHAPE, SurfData.delzSnow);
-    store_nc_scalar(ncid, AvgSurfTemp_id, T_SHAPE, AvgSurfTemp);
 
     store_nc_scalar(ncid, precip_id, XYT_SHAPE, MetData.Rain);
     store_nc_scalar(ncid,   evap_id, XYT_SHAPE, SurfData.Evap);
@@ -352,35 +335,6 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
     store_nc_scalar(ncid, wnd_id, XYT_SHAPE, MetData.WindSpeed);
 
     store_nc_scalar(ncid,  TV_id, XYT_SHAPE, LakeVolume);
-
-    //# Restart variables
-    /*------------------------------------------------------------------------*/
-    restart_variables   = malloc(17*sizeof(AED_REAL));
-    restart_variables[0] = DepMX;
-    restart_variables[1] = PrevThick;
-    restart_variables[2] = gPrimeTwoLayer;
-    restart_variables[3] = Energy_AvailableMix;
-    restart_variables[4] = Mass_Epi;
-    restart_variables[5] = OldSlope;
-    restart_variables[6] = Time_end_shear;
-    restart_variables[7] = Time_start_shear;
-    restart_variables[8] = Time_count_end_shear;
-    restart_variables[9] = Time_count_sim;
-    restart_variables[10] = Half_Seiche_Period;
-    restart_variables[11] = Thermocline_Height;
-    restart_variables[12] = FO;
-    restart_variables[13] = FSUM;
-    restart_variables[14] = u_f;
-    restart_variables[15] = u0;
-    restart_variables[16] = u_avg;
-
-
-    start_r[0] = 0; edges_r[0] = restart_len;
-
-    iret = nc_put_vara(ncid,  restart_id, start_r, edges_r, restart_variables);
-    if ( iret != NC_NOERR ) check_nc_error_x(iret, ncid, restart_id);
-
-    store_nc_integer(ncid, Mixer_Count_id, T_SHAPE, Mixer_Count);
 
     //# Time varying profile data : z,t
     /*------------------------------------------------------------------------*/
@@ -462,7 +416,7 @@ void write_glm_ncdf(int ncid, int wlev, int nlev, int stepnum, AED_REAL timestep
     free(heights); free(vols); free(area); free(salts);
     free(temps);  free(dens); free(qsw);
     free(extc_coef); free(u_mean); free(u_orb);
-    free(taub); free(restart_variables); free(epsilon);
+    free(taub); free(epsilon);
 
     check_nc_error(nc_sync(ncid));
 }

--- a/src/glm_output.c
+++ b/src/glm_output.c
@@ -355,8 +355,8 @@ void write_output(int jday, int iclock, int nsave, int stepnum)
     }
 
     /* Write intermediate NetCDF restart file if interval is set */
-    if (rst_fn != NULL && rst_nsave > 0 && (stepnum % rst_nsave == 0))
-        write_glm_restart(rst_fn);
+    if (restart_fname != NULL && restart_nsave > 0 && (stepnum % restart_nsave == 0))
+        write_glm_restart(restart_fname);
 }
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 

--- a/src/glm_restart.c
+++ b/src/glm_restart.c
@@ -61,8 +61,8 @@
 
 /*----------------------------------------------------------------------------*/
 /* Global restart configuration                                               */
-char *rst_fn    = NULL;
-int   rst_nsave = 0;
+char *restart_fname    = NULL;
+int   restart_nsave = 0;
 
 /*----------------------------------------------------------------------------*/
 /* Helpers                                                                    */

--- a/src/glm_restart.c
+++ b/src/glm_restart.c
@@ -46,6 +46,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
+
+#define WQ_NAME_LEN 48  /* matches Fortran CHARACTER(LEN=48) for AED variable names */
 
 #include <netcdf.h>
 
@@ -53,6 +56,7 @@
 #include "glm_types.h"
 #include "glm_globals.h"
 #include "glm_ncdf.h"
+#include "glm_wqual.h"
 #include "glm_restart.h"
 
 /*----------------------------------------------------------------------------*/
@@ -104,19 +108,20 @@ void write_glm_restart(const char *fn)
     rst_ncid_ = ncid;
 
     /* -------- define dimensions -------- */
-    int dim_nlev, dim_maxpar, dim_numinf, dim_wqvars, dim_wqben, dim_zones;
+    int dim_nlev, dim_maxpar, dim_numinf, dim_wqvars, dim_wqben, dim_zones, dim_wqnamelen;
     int dim_sedlayers = -1;
 
-    RST_CHECK(nc_def_dim(ncid, "nlev",        NumLayers,   &dim_nlev));
+    RST_CHECK(nc_def_dim(ncid, "nlev",        MaxLayers,   &dim_nlev));
     RST_CHECK(nc_def_dim(ncid, "max_par",     MaxPar,      &dim_maxpar));
     RST_CHECK(nc_def_dim(ncid, "num_inflows",  NumInf > 0 ? NumInf : 1,
                          &dim_numinf));
-    int nwq = (wq_calc && Tot_WQ_Vars > 0) ? Tot_WQ_Vars : 1;
-    RST_CHECK(nc_def_dim(ncid, "wq_vars",     nwq,         &dim_wqvars));
+    int nwq = (wq_calc && Num_WQ_Vars > 0) ? Num_WQ_Vars : 1;
+    RST_CHECK(nc_def_dim(ncid, "num_wq_vars", nwq,         &dim_wqvars));
     int nben = (wq_calc && Num_WQ_Ben > 0) ? Num_WQ_Ben : 1;
-    RST_CHECK(nc_def_dim(ncid, "wq_ben",      nben,        &dim_wqben));
+    RST_CHECK(nc_def_dim(ncid, "num_wq_ben",  nben,        &dim_wqben));
     RST_CHECK(nc_def_dim(ncid, "n_zones",     n_zones > 0 ? n_zones : 1,
                          &dim_zones));
+    RST_CHECK(nc_def_dim(ncid, "wq_name_len", WQ_NAME_LEN, &dim_wqnamelen));
     int n_sed_layers_rst = 0;
     if (sed_heat_model == 2 && n_zones > 0 && theZones != NULL)
         n_sed_layers_rst = theZones[0].n_sed_layers;
@@ -126,16 +131,24 @@ void write_glm_restart(const char *fn)
 
     /* PTM dimensions (only defined when particles are active) */
     static const int PTM_STAT_NVARS = 6; /* STAT,IDX2,IDX3,LAYR,FLAG,PTID */
+    static const int PTM_ENV_NVARS  = 5; /* MASS,DIAM,DENS,VVEL,HGHT (n_ptm_env) */
     int dim_ptm_par = -1, dim_ptm_sv = -1, dim_ptm_wqv = -1;
     int ptm_enabled = (ptm_sw && PTM_Stat != NULL && max_particle_num > 0) ? 1 : 0;
     if (ptm_enabled) {
-        RST_CHECK(nc_def_dim(ncid, "ptm_particles", max_particle_num, &dim_ptm_par));
-        RST_CHECK(nc_def_dim(ncid, "ptm_stat_vars", PTM_STAT_NVARS,   &dim_ptm_sv));
-        RST_CHECK(nc_def_dim(ncid, "ptm_wq_vars",   Num_WQ_Vars,      &dim_ptm_wqv));
+        RST_CHECK(nc_def_dim(ncid, "ptm_particles",  max_particle_num,            &dim_ptm_par));
+        RST_CHECK(nc_def_dim(ncid, "ptm_stat_vars",  PTM_STAT_NVARS,              &dim_ptm_sv));
+        RST_CHECK(nc_def_dim(ncid, "num_ptm_wq_vars", PTM_ENV_NVARS + Num_PTM_Vars, &dim_ptm_wqv));
     }
 
     /* -------- global attributes -------- */
+    {
+        time_t now = time(NULL);
+        char ts[32];
+        strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", gmtime(&now));
+        RST_CHECK(nc_put_att_text(ncid, NC_GLOBAL, "creation_time", strlen(ts), ts));
+    }
     RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "NumLayers",       NC_INT, 1, &NumLayers));
+    RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "MaxLayers",       NC_INT, 1, &MaxLayers));
     RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "NumInf",          NC_INT, 1, &NumInf));
     RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "Tot_WQ_Vars",     NC_INT, 1, &Tot_WQ_Vars));
     RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "Num_WQ_Ben",      NC_INT, 1, &Num_WQ_Ben));
@@ -143,20 +156,20 @@ void write_glm_restart(const char *fn)
     RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "sed_heat_model",  NC_INT, 1, &sed_heat_model));
     RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "n_sed_layers_rst",NC_INT, 1, &n_sed_layers_rst));
     RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "ptm_enabled",     NC_INT, 1, &ptm_enabled));
-    RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "max_particle_num",NC_INT, 1, &max_particle_num));
-    RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "Num_WQ_Vars",     NC_INT, 1, &Num_WQ_Vars));
+    if (ptm_enabled) {
+        RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "max_particle_num",NC_INT, 1, &max_particle_num));
+        RST_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "Num_PTM_Vars",    NC_INT, 1, &Num_PTM_Vars));
+    }
 
     /* -------- define variables -------- */
 
     /* Lake layer arrays [nlev] */
-    int id_temp, id_salt, id_height, id_layvol, id_layarea;
-    int id_meanht, id_dens, id_eps, id_umean, id_uorb, id_stress;
+    /* lake_layervol, lake_layerarea, lake_meanheight are omitted: they are
+     * re-derived from Height via the morphometry table on the first timestep. */
+    int id_temp, id_salt, id_height, id_dens, id_eps, id_umean, id_uorb, id_stress;
     def_var_d(ncid, "lake_temp",        1, &dim_nlev, &id_temp);
     def_var_d(ncid, "lake_salt",        1, &dim_nlev, &id_salt);
     def_var_d(ncid, "lake_height",      1, &dim_nlev, &id_height);
-    def_var_d(ncid, "lake_layervol",    1, &dim_nlev, &id_layvol);
-    def_var_d(ncid, "lake_layerarea",   1, &dim_nlev, &id_layarea);
-    def_var_d(ncid, "lake_meanheight",  1, &dim_nlev, &id_meanht);
     def_var_d(ncid, "lake_density",     1, &dim_nlev, &id_dens);
     def_var_d(ncid, "lake_epsilon",     1, &dim_nlev, &id_eps);
     def_var_d(ncid, "lake_umean",       1, &dim_nlev, &id_umean);
@@ -165,7 +178,7 @@ void write_glm_restart(const char *fn)
 
     /* WQ per-layer [wq_vars, nlev] (stored as flat [wq_vars * nlev]) */
     int id_wq = -1;
-    if (wq_calc && Tot_WQ_Vars > 0) {
+    if (wq_calc && Num_WQ_Vars > 0) {
         int dims2[2] = { dim_wqvars, dim_nlev };
         def_var_d(ncid, "wq_vars", 2, dims2, &id_wq);
     }
@@ -174,6 +187,17 @@ void write_glm_restart(const char *fn)
     int id_wqs = -1;
     if (wq_calc && Num_WQ_Ben > 0 && WQS_Vars != NULL) {
         def_var_d(ncid, "wqs_vars", 1, &dim_wqben, &id_wqs);
+    }
+
+    /* WQ variable name strings [num_wq_vars, wq_name_len] and [num_wq_ben, wq_name_len] */
+    int id_wqnames = -1, id_wqbennames = -1;
+    if (wq_calc && Num_WQ_Vars > 0) {
+        int dims_wn[2] = { dim_wqvars, dim_wqnamelen };
+        RST_CHECK(nc_def_var(ncid, "wq_var_names", NC_CHAR, 2, dims_wn, &id_wqnames));
+    }
+    if (wq_calc && Num_WQ_Ben > 0) {
+        int dims_wb[2] = { dim_wqben, dim_wqnamelen };
+        RST_CHECK(nc_def_var(ncid, "wq_ben_names", NC_CHAR, 2, dims_wb, &id_wqbennames));
     }
 
     /* Surface scalars */
@@ -217,7 +241,7 @@ void write_glm_restart(const char *fn)
         def_var_i(ncid, "inflow_noins", 1, &dim_numinf, &id_noins);
         def_var_i(ncid, "inflow_icnt",  1, &dim_numinf, &id_icnt);
         def_var_d(ncid, "inflow_submelev", 1, &dim_numinf, &id_submelev);
-        if (wq_calc && Tot_WQ_Vars > 0) {
+        if (wq_calc && Num_WQ_Vars > 0) {
             int dims_iw[3] = { dim_numinf, dim_maxpar, dim_wqvars };
             def_var_d(ncid, "inflow_wqins", 3, dims_iw, &id_wqins);
         }
@@ -247,20 +271,17 @@ void write_glm_restart(const char *fn)
     /* -------- write data -------- */
 
     /* Allocate a working buffer large enough for any 1-D layer array */
-    AED_REAL *buf = malloc(NumLayers * sizeof(AED_REAL));
+    AED_REAL *buf = malloc(MaxLayers * sizeof(AED_REAL));
     if (!buf) { fprintf(stderr, "glm_restart: out of memory\n"); exit(1); }
 
-    /* Lake layer fields */
+    /* Lake layer fields (all MaxLayers slots, active + unused) */
 #define WRITE_LAKE_FIELD(varid, field) \
-    do { for (int _i = 0; _i < NumLayers; _i++) buf[_i] = Lake[_i].field; \
+    do { for (int _i = 0; _i < MaxLayers; _i++) buf[_i] = Lake[_i].field; \
          RST_CHECK(nc_put_var_double(ncid, varid, buf)); } while(0)
 
     WRITE_LAKE_FIELD(id_temp,    Temp);
     WRITE_LAKE_FIELD(id_salt,    Salinity);
     WRITE_LAKE_FIELD(id_height,  Height);
-    WRITE_LAKE_FIELD(id_layvol,  LayerVol);
-    WRITE_LAKE_FIELD(id_layarea, LayerArea);
-    WRITE_LAKE_FIELD(id_meanht,  MeanHeight);
     WRITE_LAKE_FIELD(id_dens,    Density);
     WRITE_LAKE_FIELD(id_eps,     Epsilon);
     WRITE_LAKE_FIELD(id_umean,   Umean);
@@ -270,16 +291,16 @@ void write_glm_restart(const char *fn)
 
     free(buf);
 
-    /* WQ per-layer: WQ_Vars layout is [Tot_WQ_Vars * MaxLayers] with index
-     * _WQ_Vars(var, lyr) = WQ_Vars[Tot_WQ_Vars * lyr + var]
-     * We write a [wq_vars, nlev] array (contiguous in var for each layer). */
+    /* WQ per-layer: save only the Num_WQ_Vars pelagic rows (indices 0..Num_WQ_Vars-1).
+     * Benthic sheet rows (indices Num_WQ_Vars..Tot_WQ_Vars-1) are saved separately
+     * via wqs_vars.  We write a [num_wq_vars, nlev] array. */
     if (id_wq >= 0) {
-        /* Build a compact [Tot_WQ_Vars * NumLayers] buffer */
-        AED_REAL *wqbuf = malloc(Tot_WQ_Vars * NumLayers * sizeof(AED_REAL));
+        /* Build [Num_WQ_Vars * MaxLayers] buffer (all slots, active + unused) */
+        AED_REAL *wqbuf = malloc(Num_WQ_Vars * MaxLayers * sizeof(AED_REAL));
         if (!wqbuf) { fprintf(stderr, "glm_restart: out of memory\n"); exit(1); }
-        for (int v = 0; v < Tot_WQ_Vars; v++)
-            for (int l = 0; l < NumLayers; l++)
-                wqbuf[v * NumLayers + l] = _WQ_Vars(v, l);
+        for (int v = 0; v < Num_WQ_Vars; v++)
+            for (int l = 0; l < MaxLayers; l++)
+                wqbuf[v * MaxLayers + l] = _WQ_Vars(v, l);
         RST_CHECK(nc_put_var_double(ncid, id_wq, wqbuf));
         free(wqbuf);
     }
@@ -287,6 +308,47 @@ void write_glm_restart(const char *fn)
     /* Benthic WQ sheet */
     if (id_wqs >= 0)
         RST_CHECK(nc_put_var_double(ncid, id_wqs, WQS_Vars));
+
+    /* WQ variable name strings */
+    if ((id_wqnames >= 0 || id_wqbennames >= 0) && p_wq_get_var_names != NULL) {
+        char wbuf[4096] = {0}, bbuf[1024] = {0};
+        int  wlen = 0, blen = 0;
+        p_wq_get_var_names(wbuf, &wlen, bbuf, &blen);
+
+        if (id_wqnames >= 0 && wlen > 0) {
+            char *flat = calloc((size_t)(Num_WQ_Vars * WQ_NAME_LEN), 1);
+            if (!flat) { fprintf(stderr, "glm_restart: out of memory\n"); exit(1); }
+            int row = 0;
+            char *tok = wbuf;
+            while (row < Num_WQ_Vars) {
+                char *comma = strchr(tok, ',');
+                int nlen = comma ? (int)(comma - tok) : (int)strlen(tok);
+                if (nlen > WQ_NAME_LEN) nlen = WQ_NAME_LEN;
+                memcpy(flat + row * WQ_NAME_LEN, tok, nlen);
+                row++;
+                if (comma) tok = comma + 1; else break;
+            }
+            RST_CHECK(nc_put_var_text(ncid, id_wqnames, flat));
+            free(flat);
+        }
+
+        if (id_wqbennames >= 0 && blen > 0) {
+            char *flat = calloc((size_t)(Num_WQ_Ben * WQ_NAME_LEN), 1);
+            if (!flat) { fprintf(stderr, "glm_restart: out of memory\n"); exit(1); }
+            int row = 0;
+            char *tok = bbuf;
+            while (row < Num_WQ_Ben) {
+                char *comma = strchr(tok, ',');
+                int nlen = comma ? (int)(comma - tok) : (int)strlen(tok);
+                if (nlen > WQ_NAME_LEN) nlen = WQ_NAME_LEN;
+                memcpy(flat + row * WQ_NAME_LEN, tok, nlen);
+                row++;
+                if (comma) tok = comma + 1; else break;
+            }
+            RST_CHECK(nc_put_var_text(ncid, id_wqbennames, flat));
+            free(flat);
+        }
+    }
 
     /* Surface scalars */
     RST_CHECK(nc_put_var_double(ncid, id_avgt,    &AvgSurfTemp));
@@ -353,14 +415,14 @@ void write_glm_restart(const char *fn)
         for (int s = 0; s < NumInf; s++) svec[s] = Inflows[s].SubmElev;
         RST_CHECK(nc_put_var_double(ncid, id_submelev, svec));
 
-        /* WQIns [NumInf, MaxPar, Tot_WQ_Vars] */
+        /* WQIns [NumInf, MaxPar, Num_WQ_Vars] */
         if (id_wqins >= 0) {
-            AED_REAL *wibuf = malloc(NumInf * MaxPar * Tot_WQ_Vars * sizeof(AED_REAL));
+            AED_REAL *wibuf = malloc(NumInf * MaxPar * Num_WQ_Vars * sizeof(AED_REAL));
             if (!wibuf) { fprintf(stderr, "glm_restart: out of memory\n"); exit(1); }
             for (int s = 0; s < NumInf; s++)
                 for (int p = 0; p < MaxPar; p++)
-                    for (int v = 0; v < Tot_WQ_Vars; v++)
-                        wibuf[(s * MaxPar + p) * Tot_WQ_Vars + v] =
+                    for (int v = 0; v < Num_WQ_Vars; v++)
+                        wibuf[(s * MaxPar + p) * Num_WQ_Vars + v] =
                             Inflows[s].WQIns[p][v];
             RST_CHECK(nc_put_var_double(ncid, id_wqins, wibuf));
             free(wibuf);
@@ -418,9 +480,10 @@ int read_glm_restart(const char *fn)
     rst_ncid_ = ncid;
 
     /* ---- validate global attributes ---- */
-    int att_nlev, att_numinf, att_tot_wq, att_nben, att_nzones;
+    int att_nlev, att_maxlayers, att_numinf, att_tot_wq, att_nben, att_nzones;
     int att_sed_heat_model, att_n_sed_layers_rst;
     RST_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "NumLayers",      &att_nlev));
+    RST_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "MaxLayers",      &att_maxlayers));
     RST_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "NumInf",         &att_numinf));
     RST_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "Tot_WQ_Vars",    &att_tot_wq));
     RST_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "Num_WQ_Ben",     &att_nben));
@@ -428,9 +491,14 @@ int read_glm_restart(const char *fn)
     RST_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "sed_heat_model", &att_sed_heat_model));
     RST_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "n_sed_layers_rst", &att_n_sed_layers_rst));
 
-    if (att_nlev > MaxLayers) {
-        fprintf(stderr, "glm_restart: restart NumLayers (%d) > MaxLayers (%d)\n",
-                att_nlev, MaxLayers);
+    if (att_maxlayers > MaxLayers) {
+        fprintf(stderr, "glm_restart: restart MaxLayers (%d) > current MaxLayers (%d)\n",
+                att_maxlayers, MaxLayers);
+        exit(1);
+    }
+    if (att_nlev > att_maxlayers) {
+        fprintf(stderr, "glm_restart: restart NumLayers (%d) > restart MaxLayers (%d)\n",
+                att_nlev, att_maxlayers);
         exit(1);
     }
     if (att_numinf != NumInf) {
@@ -456,23 +524,20 @@ int read_glm_restart(const char *fn)
     int varid; \
     RST_CHECK(nc_inq_varid(ncid, name, &varid));
 
-    /* ---- lake layer fields ---- */
+    /* ---- lake layer fields (all MaxLayers slots) ---- */
     {
-        AED_REAL *buf = malloc(NumLayers * sizeof(AED_REAL));
+        AED_REAL *buf = malloc(att_maxlayers * sizeof(AED_REAL));
         if (!buf) { fprintf(stderr, "glm_restart: out of memory\n"); exit(1); }
 
 #define READ_LAKE_FIELD(varname, field) \
         do { int _id; RST_CHECK(nc_inq_varid(ncid, varname, &_id)); \
              RST_CHECK(nc_get_var_double(ncid, _id, buf)); \
-             for (int _i = 0; _i < NumLayers; _i++) Lake[_i].field = buf[_i]; \
+             for (int _i = 0; _i < att_maxlayers; _i++) Lake[_i].field = buf[_i]; \
         } while(0)
 
         READ_LAKE_FIELD("lake_temp",       Temp);
         READ_LAKE_FIELD("lake_salt",       Salinity);
         READ_LAKE_FIELD("lake_height",     Height);
-        READ_LAKE_FIELD("lake_layervol",   LayerVol);
-        READ_LAKE_FIELD("lake_layerarea",  LayerArea);
-        READ_LAKE_FIELD("lake_meanheight", MeanHeight);
         READ_LAKE_FIELD("lake_density",    Density);
         READ_LAKE_FIELD("lake_epsilon",    Epsilon);
         READ_LAKE_FIELD("lake_umean",      Umean);
@@ -483,24 +548,34 @@ int read_glm_restart(const char *fn)
         free(buf);
     }
 
-    /* ---- WQ per-layer ---- */
-    if (wq_calc && Tot_WQ_Vars > 0 && WQ_Vars != NULL) {
+    /* ---- WQ per-layer (all MaxLayers slots) ---- */
+    if (wq_calc && Num_WQ_Vars > 0 && WQ_Vars != NULL) {
         int id_wq;
-        RST_CHECK(nc_inq_varid(ncid, "wq_vars", &id_wq));
-        AED_REAL *wqbuf = malloc(Tot_WQ_Vars * NumLayers * sizeof(AED_REAL));
-        if (!wqbuf) { fprintf(stderr, "glm_restart: out of memory\n"); exit(1); }
-        RST_CHECK(nc_get_var_double(ncid, id_wq, wqbuf));
-        for (int v = 0; v < Tot_WQ_Vars; v++)
-            for (int l = 0; l < NumLayers; l++)
-                _WQ_Vars(v, l) = wqbuf[v * NumLayers + l];
-        free(wqbuf);
+        int wq_err = nc_inq_varid(ncid, "wq_vars", &id_wq);
+        if (wq_err == NC_NOERR) {
+            AED_REAL *wqbuf = malloc(Num_WQ_Vars * att_maxlayers * sizeof(AED_REAL));
+            if (!wqbuf) { fprintf(stderr, "glm_restart: out of memory\n"); exit(1); }
+            RST_CHECK(nc_get_var_double(ncid, id_wq, wqbuf));
+            for (int v = 0; v < Num_WQ_Vars; v++)
+                for (int l = 0; l < att_maxlayers; l++)
+                    _WQ_Vars(v, l) = wqbuf[v * att_maxlayers + l];
+            free(wqbuf);
+        } else {
+            fprintf(stderr, "     WARNING: restart has no wq_vars variable; "
+                    "WQ state initialised from NML.\n");
+        }
     }
 
     /* ---- Benthic WQ sheet ---- */
     if (wq_calc && Num_WQ_Ben > 0 && WQS_Vars != NULL) {
         int id_wqs;
-        RST_CHECK(nc_inq_varid(ncid, "wqs_vars", &id_wqs));
-        RST_CHECK(nc_get_var_double(ncid, id_wqs, WQS_Vars));
+        int wqs_err = nc_inq_varid(ncid, "wqs_vars", &id_wqs);
+        if (wqs_err == NC_NOERR) {
+            RST_CHECK(nc_get_var_double(ncid, id_wqs, WQS_Vars));
+        } else {
+            fprintf(stderr, "     WARNING: restart has no wqs_vars variable; "
+                    "benthic WQ state initialised from NML.\n");
+        }
     }
 
     /* ---- Surface scalars ---- */
@@ -589,17 +664,17 @@ int read_glm_restart(const char *fn)
             for (int s = 0; s < NumInf; s++) Inflows[s].SubmElev = svec[s];
         }
 
-        if (wq_calc && Tot_WQ_Vars > 0) {
-            AED_REAL *wibuf = malloc(NumInf * MaxPar * Tot_WQ_Vars * sizeof(AED_REAL));
+        if (wq_calc && Num_WQ_Vars > 0) {
+            AED_REAL *wibuf = malloc(NumInf * MaxPar * Num_WQ_Vars * sizeof(AED_REAL));
             if (!wibuf) { fprintf(stderr, "glm_restart: out of memory\n"); exit(1); }
             int _id;
             RST_CHECK(nc_inq_varid(ncid, "inflow_wqins", &_id));
             RST_CHECK(nc_get_var_double(ncid, _id, wibuf));
             for (int s = 0; s < NumInf; s++)
                 for (int p = 0; p < MaxPar; p++)
-                    for (int v = 0; v < Tot_WQ_Vars; v++)
+                    for (int v = 0; v < Num_WQ_Vars; v++)
                         Inflows[s].WQIns[p][v] =
-                            wibuf[(s * MaxPar + p) * Tot_WQ_Vars + v];
+                            wibuf[(s * MaxPar + p) * Num_WQ_Vars + v];
             free(wibuf);
         }
 
@@ -630,12 +705,12 @@ int read_glm_restart(const char *fn)
 
     /* ---- PTM particle state ---- */
     {
-        int att_ptm_en = 0, att_max_ptm = 0, att_nwq = 0;
+        int att_ptm_en = 0, att_max_ptm = 0, att_ptm_vars = 0;
         /* Use nc_get_att_int without RST_CHECK — attribute may be absent in
          * older restart files; errors here are non-fatal. */
         nc_get_att_int(ncid, NC_GLOBAL, "ptm_enabled",     &att_ptm_en);
         nc_get_att_int(ncid, NC_GLOBAL, "max_particle_num",&att_max_ptm);
-        nc_get_att_int(ncid, NC_GLOBAL, "Num_WQ_Vars",     &att_nwq);
+        nc_get_att_int(ncid, NC_GLOBAL, "Num_PTM_Vars",    &att_ptm_vars);
 
         if (att_ptm_en) {
             if (!ptm_sw || PTM_Stat == NULL) {
@@ -645,10 +720,10 @@ int read_glm_restart(const char *fn)
                 fprintf(stderr, "     WARNING: restart max_particle_num (%d) "
                         "!= current (%d); particle state skipped.\n",
                         att_max_ptm, max_particle_num);
-            } else if (att_nwq != Num_WQ_Vars) {
-                fprintf(stderr, "     WARNING: restart Num_WQ_Vars (%d) "
+            } else if (att_ptm_vars != Num_PTM_Vars) {
+                fprintf(stderr, "     WARNING: restart Num_PTM_Vars (%d) "
                         "!= current (%d); particle state skipped.\n",
-                        att_nwq, Num_WQ_Vars);
+                        att_ptm_vars, Num_PTM_Vars);
             } else {
                 int _id;
                 RST_CHECK(nc_inq_varid(ncid, "ptm_stat", &_id));

--- a/src/glm_restart.h
+++ b/src/glm_restart.h
@@ -31,9 +31,9 @@
 #define _GLM_RESTART_H_
 
 /* Name of the restart file (NULL => no NetCDF restart) */
-extern char *rst_fn;
-/* Write restart every rst_nsave steps (<=0 => only at end) */
-extern int   rst_nsave;
+extern char *restart_fname;
+/* Write restart every restart_nsave steps (<=0 => only at end) */
+extern int   restart_nsave;
 
 /*
  * write_glm_restart: write all model state to a NetCDF restart file.

--- a/src/glm_wqual.c
+++ b/src/glm_wqual.c
@@ -66,6 +66,7 @@ wq_is_var_t          p_wq_is_var          = NULL;
 wq_set_glm_zones_t   p_wq_set_glm_zones   = NULL;
 wq_ZSoilTemp_t       p_wq_ZSoilTemp       = NULL;
 wq_inflow_update_t   p_wq_inflow_update   = (wq_inflow_update_t)dummy_inflow_update;
+wq_get_var_names_t   p_wq_get_var_names   = NULL;
 
 void glm_init_fortran_support(void);
 
@@ -134,6 +135,8 @@ int prime_wq(const char *which)
     p_wq_ZSoilTemp       =       (wq_ZSoilTemp_t) find_entry(glm_wq_handle, "zZSoilTemp");
     if ( p_wq_ZSoilTemp == NULL ) p_wq_ZSoilTemp = (wq_ZSoilTemp_t) dummyZSoilTemp;
     p_wq_inflow_update   =   (wq_inflow_update_t) find_entry(glm_wq_handle, "wq_inflow_update");
+    /* optional — not present in older plugin builds */
+    p_wq_get_var_names   =   (wq_get_var_names_t) dlsym(glm_wq_handle, "wq_get_var_names");
 #ifdef _WIN32
     p_set_funcs          =          (set_funcs_t) find_entry(glm_wq_handle, "set_funcs");
 
@@ -187,8 +190,8 @@ int prime_wq(const char *which)
         p_wq_var_index_c     =     (wq_var_index_c_t) aed_var_index_c;
         p_wq_is_var          =          (wq_is_var_t) aed_is_var;
         p_wq_inflow_update   =   (wq_inflow_update_t) aed_update_inflow_wq;
+        p_wq_get_var_names   =   (wq_get_var_names_t) aed_get_var_names;
 #else
-        fprintf(stderr, "AED not supported in this build\n");
         exit(1);
 #endif
 
@@ -204,6 +207,7 @@ int prime_wq(const char *which)
         p_wq_var_index_c     =     (wq_var_index_c_t) api_var_index_c;
         p_wq_is_var          =          (wq_is_var_t) api_is_var;
         p_wq_inflow_update   =   (wq_inflow_update_t) api_update_inflow_wq;
+        p_wq_get_var_names   =   (wq_get_var_names_t) api_get_var_names;
 #else
         fprintf(stderr, "API not supported in this build\n");
         exit(1);

--- a/src/glm_wqual.h
+++ b/src/glm_wqual.h
@@ -47,6 +47,7 @@ typedef void (*wq_set_glm_zones_t)(int *numVars, int *numBenV, int *numDiagV, in
 typedef void (*wq_ZSoilTemp_t)(ZoneType *zone);
 
 typedef void (*wq_inflow_update_t)(AED_REAL *wqinf, int *nwqVars, AED_REAL *temp, AED_REAL *salt);
+typedef void (*wq_get_var_names_t)(char *wbuf, int *wlen, char *bbuf, int *blen);
 
 
 extern wq_init_glm_t        p_wq_init_glm;
@@ -59,6 +60,7 @@ extern wq_var_index_c_t     p_wq_var_index_c;
 extern wq_is_var_t          p_wq_is_var;
 extern wq_ZSoilTemp_t       p_wq_ZSoilTemp;
 extern wq_inflow_update_t   p_wq_inflow_update;
+extern wq_get_var_names_t   p_wq_get_var_names;
 
 #define wq_init_glm        (*p_wq_init_glm)
 #define wq_set_glm_data    (*p_wq_set_glm_data)
@@ -70,6 +72,7 @@ extern wq_inflow_update_t   p_wq_inflow_update;
 #define wq_is_var          (*p_wq_is_var)
 #define ZSoilTemp          (*p_wq_ZSoilTemp)
 #define wq_inflow_update   (*p_wq_inflow_update)
+#define wq_get_var_names   (*p_wq_get_var_names)
 
 int prime_wq(const char *which);
 
@@ -111,6 +114,7 @@ void api_write_glm(int *ncid, int *wlev, int *nlev, int *lvl, int *point_nlevs);
 int  api_var_index_c(const char*name, size_t *len);
 int  api_is_var(int *id, const char *v, size_t *len);
 void api_update_inflow_wq(AED_REAL *wqinf, int *nwqVars, AED_REAL *temp, AED_REAL *salt);
+void api_get_var_names(char *wbuf, int *wlen, char *bbuf, int *blen);
 #endif
 
 #if AED
@@ -123,6 +127,7 @@ void aed_write_glm(int *ncid, int *wlev, int *nlev, int *lvl, int *point_nlevs);
 int  aed_var_index_c(const char*name, size_t *len);
 int  aed_is_var(int *id, const char *v, size_t *len);
 void aed_update_inflow_wq(AED_REAL *wqinf, int *nwqVars, AED_REAL *temp, AED_REAL *salt);
+void aed_get_var_names(char *wbuf, int *wlen, char *bbuf, int *blen);
 #endif
 
 #if AED2


### PR DESCRIPTION
This PR adds the ability to write a restart file containing all the variables needed to restart the model, including mixing and inflow variables.  It can read from that restart file to hot-start a simulation.  It removes the existing restart variables in the nml.  These variables are included in the netcdf restart and were incomplete.