### PR TITLE
getting restart working for non-00:00 restarts

### DIFF
--- a/src/glm_globals.c
+++ b/src/glm_globals.c
@@ -114,6 +114,9 @@ MetDataType* pMetData = &MetData;       //# pointer to Meteorological data
 SurfaceDataType SurfData;               //# Surface Data
 SurfaceDataType* pSurfData = &SurfData; //# pointer to Surface Data
 
+int Restart_loaded = 0;
+AED_REAL Restart_SWold = 0.0;
+
 int subdaily = FALSE;
 
 //------------------------------------------------------------------------------

--- a/src/glm_globals.h
+++ b/src/glm_globals.h
@@ -175,6 +175,20 @@ extern AED_REAL mol_diffusivity[];
 // SURFACE
 extern SurfaceDataType SurfData; //# Surface Data
 extern MetDataType MetData;      //# Meteorological data
+
+// Set when a restart file has been loaded this run. Gates the restart-resume
+// handling: skipping the init_model resize_internals/check_layer_thickness
+// (the saved derived layer fields are used verbatim), and the mid-day-resume
+// overrides in do_model / do_model_non_avg.
+extern int Restart_loaded;
+
+// Sub-daily-level SWold at the end of the last sub-iter executed in the
+// previous run. On a mid-day resume it seeds the first sub-iter's SWold so it
+// matches what a continuous run had at iclock=startTOD. Only consumed in
+// non-subdaily mode (subdaily=.false.), where calculate_qsw interpolates the
+// timestep's shortwave from yesterday's (SWold) and today's daily totals; in
+// subdaily mode calculate_qsw ignores SWold so this has no effect.
+extern AED_REAL Restart_SWold;
 extern AED_REAL runoff_coef;
 extern AED_REAL rain_threshold;
 extern CLOGICAL catchrain;

--- a/src/glm_model.c
+++ b/src/glm_model.c
@@ -173,11 +173,19 @@ void init_model(int *jstart, int *nsave)
     //# Create the output files.
     init_output(*jstart, out_dir, out_fn, MaxLayers, Longitude, Latitude);
 
-    //# Calculate cumulative layer volumes from layer depths
-    resize_internals(1, botmLayer);
+    //# Calculate cumulative layer volumes from layer depths.
+    //# Skip when state was loaded from a restart file: the restart now
+    //# preserves LayerVol/LayerArea/Vol1/MeanHeight directly, and recomputing
+    //# them here from Heights introduces ~1e-12 roundoff drift vs. the
+    //# continuous run's stored values.
+    if (!Restart_loaded) resize_internals(1, botmLayer);
 
-    //# Check layers for vmax,vmin
-    check_layer_thickness();
+    //# Check layers for vmax,vmin.
+    //# Skip when state was loaded from a restart file: the saved state
+    //# already had subdaily-level check_layer_thickness run; invoking it
+    //# here on a partial-end restart would merge layers at an instant a
+    //# continuous run never visits, breaking bit-for-bit resume.
+    if (!Restart_loaded) check_layer_thickness();
 
     if(DepMX == 0.0) init_mixer();
 
@@ -291,6 +299,11 @@ void do_model(int jstart, int nsave)
     memset(WQNew, 0, sizeof(AED_REAL)*MaxInf*MaxVars);
     memset(WQOld, 0, sizeof(AED_REAL)*MaxInf*MaxVars);
 
+    /* See note in do_model_non_avg: a mid-day restart resume needs the loaded
+     * sub-daily state used verbatim; a midnight resume behaves like a normal
+     * day boundary. startTOD is read before do_subdaily_loop resets it. */
+    int resuming_midday = (Restart_loaded && startTOD > 0);
+
     /**************************** Start Simulation ****************************/
     fputs("\n     Simulation begins...\n", stdout);
 
@@ -305,6 +318,10 @@ void do_model(int jstart, int nsave)
     read_daily_met(jstart, &MetOld);
     MetData = MetOld;
     SWold = MetOld.ShortWave;
+    /* On a mid-day resume, seed SWold from the previous run's stop instant so
+     * iter-1's first sub-iter matches a continuous run (matters in non-subdaily
+     * mode; calculate_qsw ignores SWold when subdaily). */
+    if (resuming_midday) SWold = Restart_SWold;
 
     jday = jstart - 1;
 #ifdef PLOTS
@@ -323,7 +340,13 @@ void do_model(int jstart, int nsave)
         //# If it is the last day, adjust the stop time for the day if necessary
         if (ntot == nDates) stoptime = stopTOD;
         if (stoptime == 0) break;
-        day_fraction = (stoptime - startTOD) / iSecsPerDay;
+        //# See note in do_model_non_avg: on a mid-day resume, apply the full
+        //# day's end-of-iter lump (the previous run deferred the [0, startTOD]
+        //# portion).
+        if (resuming_midday && ntot == 1)
+            day_fraction = stoptime / iSecsPerDay;
+        else
+            day_fraction = (stoptime - startTOD) / iSecsPerDay;
 
         //# Initialise daily values for volume & heat balance reporting (lake.csv)
         SurfData.dailyRain = 0.; SurfData.dailyEvap = 0.;
@@ -376,7 +399,12 @@ void do_model(int jstart, int nsave)
         WithdrawalTemp = (WithdrTempOld + WithdrTempNew) / 2.0;
 
         read_daily_kw(jday, &DailyKw);
-        for (i = 0; i < MaxLayers; i++) Lake[i].ExtcCoefSW = DailyKw;
+        /* On a mid-day resume's first iter, keep the loaded ExtcCoefSW (it
+         * carries the bioshade_feedback contribution from the previous run);
+         * see note in glm_restart.c "lake_extc". A midnight resume resets
+         * normally, exactly as a continuous run does at a day boundary. */
+        if (!(resuming_midday && ntot == 1))
+            for (i = 0; i < MaxLayers; i++) Lake[i].ExtcCoefSW = DailyKw;
 
         //# Read & set today's meteorological data
         if (jday != jstart) read_daily_met(jday, &MetNew);
@@ -404,6 +432,13 @@ void do_model(int jstart, int nsave)
 
         //# End of forcing-mixing-diffusion loop
 
+        /* See note in do_model_non_avg: skip end-of-iter state mutations on a
+         * partial-end last iter when a restart will be written, so the writer
+         * and the resumer produce identical pre-end-of-iter state. */
+        int is_partial_end_with_restart =
+            (ntot == nDates) && (stoptime != iSecsPerDay) && (restart_fname != NULL);
+
+        if (!is_partial_end_with_restart) {
         //# Insert inflows for all streams
         SurfData.dailyInflow = do_inflows(); //# Do inflow for all streams
 
@@ -415,6 +450,7 @@ void do_model(int jstart, int nsave)
 
         //# Enforce layer limits
         check_layer_thickness();
+        }
 
         // # Write output on last time step within a day
         // # after including the inflow and outflows.
@@ -500,6 +536,16 @@ void do_model_non_avg(int jstart, int nsave)
     /*------------------------------------------------------------------------*/
     memset(WQNew, 0, sizeof(AED_REAL)*MaxInf*MaxVars);
 
+    /* "Mid-day resume": a restart was loaded AND the run starts part-way
+     * through a calendar day (startTOD>0). Only then does iter-1 continue a
+     * calendar day the previous run began — requiring the loaded sub-daily
+     * state to be used verbatim (no top-of-day resets) and the day's
+     * end-of-iter lump applied in full. A midnight resume (startTOD==0) begins
+     * a fresh calendar day and must behave exactly like a continuous run's
+     * day boundary, so none of these overrides apply. startTOD is read here
+     * before do_subdaily_loop resets it to 0. */
+    int resuming_midday = (Restart_loaded && startTOD > 0);
+
     /**************************** Start Simulation ****************************/
     fputs("\n     Simulation begins...\n", stdout);
 
@@ -507,6 +553,10 @@ void do_model_non_avg(int jstart, int nsave)
     stepnum = 0;
     stoptime = iSecsPerDay;
     SWold = 0.;
+    /* On a mid-day resume, seed SWold from the previous run's stop instant so
+     * iter-1's first sub-iter matches a continuous run (matters in non-subdaily
+     * mode; calculate_qsw ignores SWold when subdaily). */
+    if (resuming_midday) SWold = Restart_SWold;
 
     jday = jstart - 1;
 
@@ -521,7 +571,16 @@ void do_model_non_avg(int jstart, int nsave)
         //# If it is the last day, adjust the stop time for the day if necessary
         if (ntot == nDates) stoptime = stopTOD;
         if (stoptime == 0) break;
-        day_fraction = (stoptime - startTOD) / iSecsPerDay;
+        //# day_fraction scales the daily inflow/outflow/seepage/overflow lump
+        //# applied at the end of this calendar-day iter. On a mid-day resume the
+        //# previous run simulated the [0, startTOD] part of this day but deferred
+        //# its end-of-iter lump (partial-end ops skipped), so apply the full day's
+        //# lump here (as a continuous run does at this midnight) rather than only
+        //# the post-resume fraction.
+        if (resuming_midday && ntot == 1)
+            day_fraction = stoptime / iSecsPerDay;
+        else
+            day_fraction = (stoptime - startTOD) / iSecsPerDay;
 
         //# Initialise daily values for volume & heat balance reporting (lake.csv)
         SurfData.dailyRain    = 0.; SurfData.dailyEvap     = 0.;
@@ -575,7 +634,12 @@ void do_model_non_avg(int jstart, int nsave)
 
         //# Read & set today's Kw (if it is being read in)
         read_daily_kw(jday, &DailyKw);
-        for (i = 0; i < MaxLayers; i++) Lake[i].ExtcCoefSW = DailyKw;
+        /* On a mid-day resume's first iter, keep the loaded ExtcCoefSW (it
+         * carries the bioshade_feedback contribution from the previous run);
+         * see note in glm_restart.c "lake_extc". A midnight resume resets
+         * normally, exactly as a continuous run does at a day boundary. */
+        if (!(resuming_midday && ntot == 1))
+            for (i = 0; i < MaxLayers; i++) Lake[i].ExtcCoefSW = DailyKw;
 
         //# Read & set today's meteorological data
         read_daily_met(jday, &MetData);
@@ -587,6 +651,15 @@ void do_model_non_avg(int jstart, int nsave)
 
         //# End of forcing-mixing-diffusion loop
 
+        /* Skip end-of-iter state-mutating ops on a partial-end last iter when
+         * a restart will be written. Otherwise the post-subdaily check_layer_thickness
+         * (and overflow) mutate state at a mid-day instant that a continuous run
+         * never visits — breaking bit-for-bit restart. The same skip is applied
+         * on the writer and the resumer so they produce identical restart files. */
+        int is_partial_end_with_restart =
+            (ntot == nDates) && (stoptime != iSecsPerDay) && (restart_fname != NULL);
+
+        if (!is_partial_end_with_restart) {
          //# Insert inflows for all streams
         SurfData.dailyInflow = do_inflows();
 
@@ -600,6 +673,7 @@ void do_model_non_avg(int jstart, int nsave)
 
         //# Enforce layer limits
         check_layer_thickness();
+        }
 
         // # Write output on last time step within a day
         // # after including the inflow and outflows.
@@ -932,6 +1006,12 @@ int do_subdaily_loop(int stepnum, int jday, int stoptime, int nsave, AED_REAL SW
      * End of sub-daily loop                                                  *
      **************************************************************************/
 //  printf("end subdaily loop\n");
+
+    /* Capture the SWold value at loop exit — the value a continuing simulation
+     * would use as SWold on the next sub-iter. Saved to the restart so a
+     * non-subdaily mid-day resume matches a continuous run. (In subdaily mode
+     * SWold is unchanged inside the loop, so this just preserves it.) */
+    Restart_SWold = SWold;
 
 #ifdef PLOTS
     plotstep = 0;

--- a/src/glm_restart.c
+++ b/src/glm_restart.c
@@ -6,7 +6,8 @@
  *                                                                            *
  * State saved:                                                               *
  *   - Lake layer arrays (Temp, Salinity, Height, LayerVol, LayerArea,        *
- *     MeanHeight, Density, Epsilon, Umean, Uorb, LayerStress)               *
+ *     MeanHeight, Vol1, Density, Epsilon, Umean, Uorb, LayerStress,          *
+ *     ExtcCoefSW)                                                            *
  *   - WQ per-layer variables (WQ_Vars)                                       *
  *   - Surface state (AvgSurfTemp, delzBlueIce, delzWhiteIce, delzSnow,      *
  *     RhoSnow)                                                               *
@@ -164,9 +165,13 @@ void write_glm_restart(const char *fn)
     /* -------- define variables -------- */
 
     /* Lake layer arrays [nlev] */
-    /* lake_layervol, lake_layerarea, lake_meanheight are omitted: they are
-     * re-derived from Height via the morphometry table on the first timestep. */
+    /* layervol, layerarea, meanheight, vol1 are also saved here: although
+     * they're derivable from Height via the morphometry table, the values
+     * resize_internals re-computes from Heights at restart load differ from
+     * a continuous run's values by ~1e-12 (different order of operations),
+     * and that tiny drift compounds across sub-iters into ~1e-3 errors. */
     int id_temp, id_salt, id_height, id_dens, id_eps, id_umean, id_uorb, id_stress;
+    int id_extc, id_lvol, id_larea, id_mhgt, id_vol1;
     def_var_d(ncid, "lake_temp",        1, &dim_nlev, &id_temp);
     def_var_d(ncid, "lake_salt",        1, &dim_nlev, &id_salt);
     def_var_d(ncid, "lake_height",      1, &dim_nlev, &id_height);
@@ -175,6 +180,15 @@ void write_glm_restart(const char *fn)
     def_var_d(ncid, "lake_umean",       1, &dim_nlev, &id_umean);
     def_var_d(ncid, "lake_uorb",        1, &dim_nlev, &id_uorb);
     def_var_d(ncid, "lake_stress",      1, &dim_nlev, &id_stress);
+    /* ExtcCoefSW is updated each sub-iter when bioshade_feedback is on, so it
+     * carries WQ-feedback state across sub-iters. Must be saved to survive a
+     * mid-day restart; otherwise the resumer reads back the initial Kw and the
+     * very first sub-iter's surface-thermo light propagation diverges. */
+    def_var_d(ncid, "lake_extc",        1, &dim_nlev, &id_extc);
+    def_var_d(ncid, "lake_layervol",    1, &dim_nlev, &id_lvol);
+    def_var_d(ncid, "lake_layerarea",   1, &dim_nlev, &id_larea);
+    def_var_d(ncid, "lake_meanheight",  1, &dim_nlev, &id_mhgt);
+    def_var_d(ncid, "lake_vol1",        1, &dim_nlev, &id_vol1);
 
     /* WQ per-layer [wq_vars, nlev] (stored as flat [wq_vars * nlev]) */
     int id_wq = -1;
@@ -207,6 +221,14 @@ void write_glm_restart(const char *fn)
     def_var_d(ncid, "white_ice",        0, NULL, &id_white);
     def_var_d(ncid, "snow_thickness",   0, NULL, &id_snow);
     def_var_d(ncid, "rho_snow",         0, NULL, &id_rhosnow);
+
+    /* Sub-daily SWold snapshot — the SWold value at the last sub-iter executed
+     * in this run. Needed for a bit-for-bit mid-day resume in non-subdaily mode,
+     * where the first sub-iter would otherwise see the daily-read SWold rather
+     * than the value a continuous run had at that iclock. (No effect in subdaily
+     * mode, where calculate_qsw ignores SWold.) */
+    int id_rswold;
+    def_var_d(ncid, "restart_swold", 0, NULL, &id_rswold);
 
     /* Mixer scalars */
     int id_depmx, id_prevthick, id_eavail, id_oldslope;
@@ -287,6 +309,11 @@ void write_glm_restart(const char *fn)
     WRITE_LAKE_FIELD(id_umean,   Umean);
     WRITE_LAKE_FIELD(id_uorb,    Uorb);
     WRITE_LAKE_FIELD(id_stress,  LayerStress);
+    WRITE_LAKE_FIELD(id_extc,    ExtcCoefSW);
+    WRITE_LAKE_FIELD(id_lvol,    LayerVol);
+    WRITE_LAKE_FIELD(id_larea,   LayerArea);
+    WRITE_LAKE_FIELD(id_mhgt,    MeanHeight);
+    WRITE_LAKE_FIELD(id_vol1,    Vol1);
 #undef WRITE_LAKE_FIELD
 
     free(buf);
@@ -356,6 +383,9 @@ void write_glm_restart(const char *fn)
     RST_CHECK(nc_put_var_double(ncid, id_white,   &SurfData.delzWhiteIce));
     RST_CHECK(nc_put_var_double(ncid, id_snow,    &SurfData.delzSnow));
     RST_CHECK(nc_put_var_double(ncid, id_rhosnow, &SurfData.RhoSnow));
+
+    /* Sub-daily SWold (see note at definition above) */
+    RST_CHECK(nc_put_var_double(ncid, id_rswold,  &Restart_SWold));
 
     /* Mixer scalars */
     RST_CHECK(nc_put_var_double(ncid, id_depmx,    &DepMX));
@@ -543,6 +573,21 @@ int read_glm_restart(const char *fn)
         READ_LAKE_FIELD("lake_umean",      Umean);
         READ_LAKE_FIELD("lake_uorb",       Uorb);
         READ_LAKE_FIELD("lake_stress",     LayerStress);
+        /* Optional fields — gracefully tolerate older restart files. */
+#define OPT_LAKE_FIELD(varname, field) \
+        do { int _id; \
+             if (nc_inq_varid(ncid, varname, &_id) == NC_NOERR) { \
+                 RST_CHECK(nc_get_var_double(ncid, _id, buf)); \
+                 for (int _i = 0; _i < att_maxlayers; _i++) Lake[_i].field = buf[_i]; \
+             } \
+        } while (0)
+
+        OPT_LAKE_FIELD("lake_extc",       ExtcCoefSW);
+        OPT_LAKE_FIELD("lake_layervol",   LayerVol);
+        OPT_LAKE_FIELD("lake_layerarea",  LayerArea);
+        OPT_LAKE_FIELD("lake_meanheight", MeanHeight);
+        OPT_LAKE_FIELD("lake_vol1",       Vol1);
+#undef OPT_LAKE_FIELD
 #undef READ_LAKE_FIELD
 
         free(buf);
@@ -592,6 +637,13 @@ int read_glm_restart(const char *fn)
         RD_SCALAR_D("white_ice",      SurfData.delzWhiteIce);
         RD_SCALAR_D("snow_thickness", SurfData.delzSnow);
         RD_SCALAR_D("rho_snow",       SurfData.RhoSnow);
+
+        /* Sub-daily SWold — optional (older restart files may lack it). */
+        {
+            int _id;
+            if (nc_inq_varid(ncid, "restart_swold", &_id) == NC_NOERR)
+                RST_CHECK(nc_get_var_double(ncid, _id, &Restart_SWold));
+        }
 
         /* ---- Mixer scalars ---- */
         RD_SCALAR_D("mixer_dep_mx",             DepMX);
@@ -739,5 +791,6 @@ int read_glm_restart(const char *fn)
 
     nc_close(ncid);
     rst_ncid_ = -1;
+    Restart_loaded = 1;
     return 1;
 }


### PR DESCRIPTION
This pull request significantly improves the bit-for-bit reproducibility of mid-day restart/resume functionality in the GLM model by ensuring that all relevant state variables are preserved and restored exactly across restarts. The main changes include saving and restoring additional lake state fields in restart files, introducing new logic to gate initialization and time-step operations when resuming from a restart, and handling sub-daily state (notably `SWold`) to ensure seamless and exact continuation of simulations. These changes ensure that simulations resumed from a restart file produce identical results to uninterrupted runs, down to the smallest floating-point differences.

**Restart/Resume State Fidelity Improvements:**

- Added new global variables `Restart_loaded` and `Restart_SWold` to track when a restart file has been loaded and to preserve the sub-daily shortwave value (`SWold`) for exact resumption. (`[[1]](diffhunk://#diff-dd44257f8e3131d596c7e99046a6fc246074461e69697d7663c8c8d8b2aaa842R117-R119)`, `[[2]](diffhunk://#diff-03cd1645ecea47ce2cb40a86d5abb7eade252582a09c857176e9079e6795a5bfR178-R191)`)
- Modified the initialization (`init_model`) and main model stepping routines (`do_model`, `do_model_non_avg`) to skip recalculating or mutating state that would introduce roundoff drift or break bit-for-bit equivalence when resuming from a restart. This includes skipping `resize_internals` and `check_layer_thickness` when a restart is loaded, and gating end-of-iteration mutations. (`[[1]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffL176-R188)`, `[[2]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR302-R306)`, `[[3]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR321-R324)`, `[[4]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR343-R348)`, `[[5]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR402-R406)`, `[[6]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR435-R441)`, `[[7]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR453)`, `[[8]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR539-R559)`, `[[9]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR574-R582)`, `[[10]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR637-R641)`, `[[11]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR654-R662)`, `[[12]](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR676)`)

**Restart File Format and I/O Enhancements:**

- Expanded the restart file to save and restore additional lake state arrays: `ExtcCoefSW`, `LayerVol`, `LayerArea`, `MeanHeight`, and `Vol1`, as well as the sub-daily `SWold` snapshot. This ensures all derived state is preserved exactly and avoids roundoff drift on resume. Reading these fields is tolerant to older restart files that may lack them. (`[[1]](diffhunk://#diff-6349ddf8a046969bdc61cce56de86a8b00e4881452b4fb7b9e2c020a3a4d2f7dL9-R10)`, `[[2]](diffhunk://#diff-6349ddf8a046969bdc61cce56de86a8b00e4881452b4fb7b9e2c020a3a4d2f7dL167-R174)`, `[[3]](diffhunk://#diff-6349ddf8a046969bdc61cce56de86a8b00e4881452b4fb7b9e2c020a3a4d2f7dR183-R191)`, `[[4]](diffhunk://#diff-6349ddf8a046969bdc61cce56de86a8b00e4881452b4fb7b9e2c020a3a4d2f7dR225-R232)`, `[[5]](diffhunk://#diff-6349ddf8a046969bdc61cce56de86a8b00e4881452b4fb7b9e2c020a3a4d2f7dR312-R316)`, `[[6]](diffhunk://#diff-6349ddf8a046969bdc61cce56de86a8b00e4881452b4fb7b9e2c020a3a4d2f7dR387-R389)`, `[[7]](diffhunk://#diff-6349ddf8a046969bdc61cce56de86a8b00e4881452b4fb7b9e2c020a3a4d2f7dR576-R590)`, `[[8]](diffhunk://#diff-6349ddf8a046969bdc61cce56de86a8b00e4881452b4fb7b9e2c020a3a4d2f7dR641-R647)`)
- Set `Restart_loaded` when a restart file is read to gate resume logic throughout the model. (`[src/glm_restart.cR794](diffhunk://#diff-6349ddf8a046969bdc61cce56de86a8b00e4881452b4fb7b9e2c020a3a4d2f7dR794)`)

**Sub-daily State Handling:**

- Captured the value of `SWold` at the end of sub-daily stepping and included it in the restart file, ensuring that upon resume the first sub-iteration matches a continuous run (especially important in non-subdaily mode). (`[src/glm_model.cR1010-R1015](diffhunk://#diff-20cf80547e44e6cafb9e65d16b4e822552341334ef5cc8d708f5bddfaba8f5ffR1010-R1015)`)

These changes collectively ensure that interrupted simulations can be resumed with zero loss of fidelity, supporting robust workflow automation and scientific reproducibility.